### PR TITLE
feat: add first authenticated Supabase Management API tool

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,11 +1,12 @@
 import type { Plugin } from "@opencode-ai/plugin";
 
 import { createSupabaseAuth } from "./auth.ts";
+import { createSupabaseTools } from "./tools.ts";
 
 const server: Plugin = async (input, options) => {
   return {
     auth: createSupabaseAuth(input, options),
-    tool: undefined,
+    tool: createSupabaseTools(input, options),
   };
 };
 

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -1,5 +1,6 @@
 import type { PluginInput } from "@opencode-ai/plugin";
-import { join } from "node:path";
+import { mkdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
 
 type StoreInput = Pick<PluginInput, "directory" | "worktree">;
 
@@ -36,11 +37,13 @@ export async function read(input: StoreInput): Promise<SavedState> {
 
 export async function write(input: StoreInput, auth: SavedAuth): Promise<void> {
   const path = file(input);
+  await mkdir(dirname(path), { recursive: true });
   await Bun.write(path, JSON.stringify({ version: 1, auth }, null, 2));
 }
 
 export async function clear(input: StoreInput): Promise<void> {
   const path = file(input);
+  await mkdir(dirname(path), { recursive: true });
   await Bun.write(path, JSON.stringify({ version: 1 }, null, 2));
 }
 

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -1,0 +1,88 @@
+import type { PluginInput, PluginOptions } from "@opencode-ai/plugin";
+import { tool } from "@opencode-ai/plugin";
+
+import {
+  BrokerClientError,
+  refreshTokenThroughBroker,
+} from "../shared/broker.ts";
+import { supabaseManagementApiFetch } from "../shared/api.ts";
+import { readSupabaseConfig } from "../shared/cfg.ts";
+import type { FetchLike } from "../shared/types.ts";
+import { readSavedAuth, writeSavedAuth, type SavedAuth } from "./store.ts";
+
+type ToolDeps = {
+  fetch?: FetchLike;
+};
+
+function isExpired(auth: SavedAuth) {
+  return auth.expires <= Date.now();
+}
+
+export async function ensureSupabaseToolAuth(
+  input: Pick<PluginInput, "directory" | "worktree">,
+  options?: PluginOptions,
+  deps: ToolDeps = {},
+): Promise<SavedAuth> {
+  const saved = await readSavedAuth(input);
+  if (!saved.auth) {
+    throw new Error("No saved Supabase auth found. Please run /supabase first.");
+  }
+
+  if (!isExpired(saved.auth)) {
+    return saved.auth;
+  }
+
+  const config = readSupabaseConfig(options);
+
+  try {
+    const refreshed = await refreshTokenThroughBroker(
+      { baseUrl: config.brokerBaseUrl },
+      { refresh_token: saved.auth.refresh },
+      deps.fetch,
+    );
+
+    const nextAuth: SavedAuth = {
+      access: refreshed.access_token,
+      refresh: refreshed.refresh_token,
+      expires: Date.now() + (refreshed.expires_in ?? 3600) * 1000,
+    };
+    await writeSavedAuth(input, nextAuth);
+    return nextAuth;
+  } catch (error) {
+    if (error instanceof BrokerClientError) {
+      throw new Error(`Supabase auth refresh failed: ${error.message}`);
+    }
+    throw error;
+  }
+}
+
+export function createSupabaseTools(
+  input: Pick<PluginInput, "directory" | "worktree">,
+  options?: PluginOptions,
+  deps: ToolDeps = {},
+) {
+  return {
+    supabase_list_projects: tool({
+      description: "List all Supabase projects for the authenticated user.",
+      args: {},
+      async execute() {
+        const config = readSupabaseConfig(options);
+        const auth = await ensureSupabaseToolAuth(input, options, deps);
+        const response = await supabaseManagementApiFetch(
+          config,
+          auth.access,
+          "/projects",
+          undefined,
+          deps.fetch,
+        );
+
+        if (!response.ok) {
+          const body = await response.text().catch(() => "");
+          throw new Error(`Failed to list projects: ${response.status} ${body}`.trim());
+        }
+
+        return JSON.stringify(await response.json(), null, 2);
+      },
+    }),
+  };
+}

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,5 +1,23 @@
 export const DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL = "https://api.supabase.com/v1/oauth/authorize";
 export const DEFAULT_SUPABASE_API_BASE_URL = "https://api.supabase.com/v1";
 
-// Token exchange and refresh are now handled by the broker
-// See src/shared/broker.ts for broker client implementation
+import type { FetchLike, SupabaseSharedConfig } from "./types.ts";
+
+export async function supabaseManagementApiFetch(
+  config: Pick<SupabaseSharedConfig, "apiBaseUrl">,
+  accessToken: string,
+  path: string,
+  init?: RequestInit,
+  fetchImpl: FetchLike = fetch,
+): Promise<Response> {
+  const url = `${config.apiBaseUrl.replace(/\/$/, "")}${path.startsWith("/") ? path : `/${path}`}`;
+
+  return fetchImpl(url, {
+    ...init,
+    headers: {
+      Accept: "application/json",
+      Authorization: `Bearer ${accessToken}`,
+      ...(init?.headers ?? {}),
+    },
+  });
+}

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -1,0 +1,174 @@
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+
+import {
+  createSupabaseTools,
+  ensureSupabaseToolAuth,
+} from "../src/server/tools.ts";
+import { readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
+import type { FetchLike } from "../src/shared/types.ts";
+
+type PluginLikeInput = {
+  directory: string;
+  worktree: string;
+};
+
+const cleanupPaths: string[] = [];
+const originalBrokerUrl = process.env.OPENCODE_SUPABASE_BROKER_URL;
+
+async function createInput(): Promise<PluginLikeInput> {
+  const root = await mkdtemp(join(tmpdir(), "opencode-supabase-tools-"));
+  cleanupPaths.push(root);
+  return {
+    directory: join(root, "consumer"),
+    worktree: root,
+  };
+}
+
+afterEach(async () => {
+  await Promise.all(cleanupPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
+  if (originalBrokerUrl === undefined) {
+    delete process.env.OPENCODE_SUPABASE_BROKER_URL;
+  } else {
+    process.env.OPENCODE_SUPABASE_BROKER_URL = originalBrokerUrl;
+  }
+});
+
+describe("server tools auth helper", () => {
+  test("fails clearly when no persisted Supabase auth exists", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+
+    await expect(
+      ensureSupabaseToolAuth(
+        input,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17670,
+        },
+        { fetch: mock(async () => new Response("unexpected")) as never },
+      ),
+    ).rejects.toThrow("No saved Supabase auth found. Please run /supabase first.");
+  });
+
+  test("uses persisted plugin-owned auth for management API requests when access is still valid", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input as never, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://api.supabase.com/v1/projects");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer saved-access",
+        Accept: "application/json",
+      });
+
+      return new Response(JSON.stringify([{ id: "proj_123", name: "Example" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17671,
+      },
+      { fetch: fetchMock as unknown as FetchLike },
+    );
+
+    const result = await tools.supabase_list_projects.execute({}, {
+      directory: input.directory,
+      worktree: input.worktree,
+      abort: new AbortController().signal,
+      sessionID: "session",
+      messageID: "message",
+      agent: "agent",
+      metadata: () => {},
+      ask: async () => {},
+    });
+
+    expect(result).toContain("proj_123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("refreshes expired persisted auth through the broker before calling the management API", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input as never, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+      if (url === "https://example.com/broker/refresh") {
+        expect(init?.method).toBe("POST");
+        expect(JSON.parse(String(init?.body))).toEqual({
+          refresh_token: "saved-refresh",
+        });
+
+        return new Response(
+          JSON.stringify({
+            access_token: "fresh-access",
+            refresh_token: "fresh-refresh",
+            expires_in: 3600,
+            token_type: "bearer",
+          }),
+          {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      expect(url).toBe("https://api.supabase.com/v1/projects");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer fresh-access",
+        Accept: "application/json",
+      });
+
+      return new Response(JSON.stringify([{ id: "proj_456" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17672,
+      },
+      { fetch: fetchMock as unknown as FetchLike },
+    );
+
+    const result = await tools.supabase_list_projects.execute({}, {
+      directory: input.directory,
+      worktree: input.worktree,
+      abort: new AbortController().signal,
+      sessionID: "session",
+      messageID: "message",
+      agent: "agent",
+      metadata: () => {},
+      ask: async () => {},
+    });
+
+    expect(result).toContain("proj_456");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await expect(readSavedAuth(input as never)).resolves.toMatchObject({
+      version: 1,
+      auth: {
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+      },
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add `supabase_list_projects` as the first real authenticated Supabase Management API tool
- add shared server-side helpers for persisted plugin-owned auth reuse, broker-backed refresh, and authenticated Management API requests
- add tests covering missing auth guidance, persisted-auth tool use, and expired-token refresh behavior

## What Changed
- wire `createSupabaseTools(...)` into the server plugin so the external plugin now exposes `supabase_list_projects`
- add `ensureSupabaseToolAuth(...)` in `src/server/tools.ts` to read `.opencode/supabase-auth.json`, fail with a clear `Please run /supabase first.` message when missing, and refresh through the broker if the saved token is expired
- add `supabaseManagementApiFetch(...)` in `src/shared/api.ts` so future Supabase Management API tools can share one authenticated HTTP helper
- ensure the plugin-owned auth store creates its parent directory before writes so persisted auth survives normal file creation paths

## Verification
- `bun run typecheck`
- `bun test`
- manual check: authenticated with `/supabase`, ran `supabase_list_projects`, restarted OpenCode, and confirmed the same tool works again without re-login

## Example
After connecting once with `/supabase`, the assistant can call:

```text
supabase_list_projects
```

and the tool should return the authenticated account's project list using the plugin-owned saved auth.

## Warnings
- this PR intentionally covers only the first vertical slice from Phase 3 / Task 8; the remaining tools and full invalid-refresh recovery behavior are still follow-up work in Task 9
- exchange and refresh remain broker-only by design; this change does not add custom routes or bypass the broker

## Relevant Context
- `PLAN.md` - Phase 3 / Task 8
- `docs/supabase-oauth-broker-contract.md`