### PR TITLE
feat(server): harden Supabase tool auth and add read-only tools

### DIFF
--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -43,9 +43,10 @@ type SupabaseToolContext = Pick<
 >;
 
 const NOT_CONNECTED_MESSAGE = "Supabase is not connected. Run /supabase first.";
+const REFRESH_BUFFER_MS = 30_000;
 
-function isExpired(auth: SavedAuth) {
-  return auth.expires <= Date.now();
+function isRefreshNeeded(auth: SavedAuth) {
+  return auth.expires <= Date.now() + REFRESH_BUFFER_MS;
 }
 
 async function executeSupabaseGet(
@@ -94,7 +95,10 @@ async function clearHostAuth(
   fetchImpl: FetchLike,
 ) {
   const url = new URL(`/auth/supabase?directory=${encodeURIComponent(input.directory)}`, input.serverUrl);
-  await fetchImpl(url.toString(), { method: "DELETE" });
+  const response = await fetchImpl(url.toString(), { method: "DELETE" });
+  if (!response.ok) {
+    throw new Error(`Failed to clear host auth: ${response.status}`);
+  }
 }
 
 export async function ensureSupabaseToolAuth(
@@ -108,7 +112,7 @@ export async function ensureSupabaseToolAuth(
     throw new Error(NOT_CONNECTED_MESSAGE);
   }
 
-  if (!isExpired(saved.auth)) {
+  if (!isRefreshNeeded(saved.auth)) {
     return saved.auth;
   }
 
@@ -127,12 +131,16 @@ export async function ensureSupabaseToolAuth(
       expires: Date.now() + (refreshed.expires_in ?? 3600) * 1000,
     };
     await writeSavedAuth(input, nextAuth);
-    await setHostAuth(input, nextAuth);
+    try {
+      await setHostAuth(input, nextAuth);
+    } catch {}
     return nextAuth;
   } catch (error) {
     if (error instanceof BrokerClientError && (error.status === 401 || error.status === 400)) {
       await clearSavedAuth(input);
-      await clearHostAuth(input, fetchImpl);
+      try {
+        await clearHostAuth(input, fetchImpl);
+      } catch {}
       throw new Error(NOT_CONNECTED_MESSAGE);
     }
 

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -1,4 +1,5 @@
-import type { PluginInput, PluginOptions } from "@opencode-ai/plugin";
+import type { PluginOptions } from "@opencode-ai/plugin";
+import type { ToolContext } from "@opencode-ai/plugin/tool";
 import { tool } from "@opencode-ai/plugin";
 
 import {
@@ -8,24 +9,103 @@ import {
 import { supabaseManagementApiFetch } from "../shared/api.ts";
 import { readSupabaseConfig } from "../shared/cfg.ts";
 import type { FetchLike } from "../shared/types.ts";
-import { readSavedAuth, writeSavedAuth, type SavedAuth } from "./store.ts";
+import { clearSavedAuth, readSavedAuth, writeSavedAuth, type SavedAuth } from "./store.ts";
 
 type ToolDeps = {
   fetch?: FetchLike;
 };
 
+type HostAuthWriter = {
+  set(input: {
+    path: { id: string };
+    query: { directory: string };
+    body: {
+      type: "oauth";
+      access: string;
+      refresh: string;
+      expires: number;
+    };
+  }): Promise<unknown>;
+};
+
+export type SupabaseToolInput = {
+  client: {
+    auth: HostAuthWriter;
+  };
+  directory: string;
+  serverUrl: URL;
+  worktree: string;
+};
+
+type SupabaseToolContext = Pick<
+  ToolContext,
+  "directory" | "worktree" | "abort" | "sessionID" | "messageID" | "agent" | "metadata" | "ask"
+>;
+
+const NOT_CONNECTED_MESSAGE = "Supabase is not connected. Run /supabase first.";
+
 function isExpired(auth: SavedAuth) {
   return auth.expires <= Date.now();
 }
 
+async function executeSupabaseGet(
+  input: SupabaseToolInput,
+  options: PluginOptions | undefined,
+  deps: ToolDeps,
+  path: string,
+  errorLabel: string,
+) {
+  const config = readSupabaseConfig(options);
+  const auth = await ensureSupabaseToolAuth(input, options, deps);
+  const response = await supabaseManagementApiFetch(
+    config,
+    auth.access,
+    path,
+    undefined,
+    deps.fetch,
+  );
+
+  if (!response.ok) {
+    const body = await response.text().catch(() => "");
+    throw new Error(`Failed to ${errorLabel}: ${response.status} ${body}`.trim());
+  }
+
+  return JSON.stringify(await response.json(), null, 2);
+}
+
+async function setHostAuth(
+  input: Pick<SupabaseToolInput, "client" | "directory">,
+  auth: SavedAuth,
+) {
+  await input.client.auth.set({
+    path: { id: "supabase" },
+    query: { directory: input.directory },
+    body: {
+      type: "oauth",
+      access: auth.access,
+      refresh: auth.refresh,
+      expires: auth.expires,
+    },
+  });
+}
+
+async function clearHostAuth(
+  input: Pick<SupabaseToolInput, "directory" | "serverUrl">,
+  fetchImpl: FetchLike,
+) {
+  const url = new URL(`/auth/supabase?directory=${encodeURIComponent(input.directory)}`, input.serverUrl);
+  await fetchImpl(url.toString(), { method: "DELETE" });
+}
+
 export async function ensureSupabaseToolAuth(
-  input: Pick<PluginInput, "directory" | "worktree">,
+  input: SupabaseToolInput,
   options?: PluginOptions,
   deps: ToolDeps = {},
 ): Promise<SavedAuth> {
+  const fetchImpl = deps.fetch ?? fetch;
   const saved = await readSavedAuth(input);
   if (!saved.auth) {
-    throw new Error("No saved Supabase auth found. Please run /supabase first.");
+    throw new Error(NOT_CONNECTED_MESSAGE);
   }
 
   if (!isExpired(saved.auth)) {
@@ -47,8 +127,15 @@ export async function ensureSupabaseToolAuth(
       expires: Date.now() + (refreshed.expires_in ?? 3600) * 1000,
     };
     await writeSavedAuth(input, nextAuth);
+    await setHostAuth(input, nextAuth);
     return nextAuth;
   } catch (error) {
+    if (error instanceof BrokerClientError && (error.status === 401 || error.status === 400)) {
+      await clearSavedAuth(input);
+      await clearHostAuth(input, fetchImpl);
+      throw new Error(NOT_CONNECTED_MESSAGE);
+    }
+
     if (error instanceof BrokerClientError) {
       throw new Error(`Supabase auth refresh failed: ${error.message}`);
     }
@@ -57,31 +144,38 @@ export async function ensureSupabaseToolAuth(
 }
 
 export function createSupabaseTools(
-  input: Pick<PluginInput, "directory" | "worktree">,
+  input: SupabaseToolInput,
   options?: PluginOptions,
   deps: ToolDeps = {},
 ) {
   return {
+    supabase_list_organizations: tool({
+      description: "List all Supabase organizations for the authenticated user.",
+      args: {},
+      async execute(_args, _context: SupabaseToolContext) {
+        return executeSupabaseGet(input, options, deps, "/organizations", "list organizations");
+      },
+    }),
     supabase_list_projects: tool({
       description: "List all Supabase projects for the authenticated user.",
       args: {},
-      async execute() {
-        const config = readSupabaseConfig(options);
-        const auth = await ensureSupabaseToolAuth(input, options, deps);
-        const response = await supabaseManagementApiFetch(
-          config,
-          auth.access,
-          "/projects",
-          undefined,
-          deps.fetch,
+      async execute(_args, _context: SupabaseToolContext) {
+        return executeSupabaseGet(input, options, deps, "/projects", "list projects");
+      },
+    }),
+    supabase_get_project_api_keys: tool({
+      description: "Get the API keys for a Supabase project.",
+      args: {
+        project_ref: tool.schema.string().describe("Project reference ID"),
+      },
+      async execute(args, _context: SupabaseToolContext) {
+        return executeSupabaseGet(
+          input,
+          options,
+          deps,
+          `/projects/${args.project_ref}/api-keys`,
+          "get API keys",
         );
-
-        if (!response.ok) {
-          const body = await response.text().catch(() => "");
-          throw new Error(`Failed to list projects: ${response.status} ${body}`.trim());
-        }
-
-        return JSON.stringify(await response.json(), null, 2);
       },
     }),
   };

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -14,6 +14,13 @@ import type { FetchLike } from "../src/shared/types.ts";
 
 type TestPluginInput = SupabaseToolInput;
 
+type HostAuthSetMock = ReturnType<typeof mock>;
+
+type TestFixtures = {
+  hostAuthSet: HostAuthSetMock;
+  input: TestPluginInput;
+};
+
 type TestToolContext = Pick<
   ToolContext,
   "directory" | "worktree" | "abort" | "sessionID" | "messageID" | "agent" | "metadata" | "ask"
@@ -22,13 +29,14 @@ type TestToolContext = Pick<
 const cleanupPaths: string[] = [];
 const originalBrokerUrl = process.env.OPENCODE_SUPABASE_BROKER_URL;
 
-async function createInput(): Promise<TestPluginInput> {
+async function createInput(): Promise<TestFixtures> {
   const root = await mkdtemp(join(tmpdir(), "opencode-supabase-tools-"));
   cleanupPaths.push(root);
+  const hostAuthSet = mock(async () => ({ data: true }));
   const input = {
     client: {
       auth: {
-        set: mock(async () => ({ data: true })),
+        set: hostAuthSet,
       },
     },
     directory: join(root, "consumer"),
@@ -36,7 +44,7 @@ async function createInput(): Promise<TestPluginInput> {
     serverUrl: new URL("http://127.0.0.1:7777/"),
   } satisfies TestPluginInput;
 
-  return input;
+  return { hostAuthSet, input };
 }
 
 function createContext(input: TestPluginInput): TestToolContext {
@@ -63,7 +71,7 @@ afterEach(async () => {
 
 describe("server tools auth helper", () => {
   test("fails clearly when no persisted Supabase auth exists", async () => {
-    const input = await createInput();
+    const { input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
 
     await expect(
@@ -79,7 +87,7 @@ describe("server tools auth helper", () => {
   });
 
   test("updates host auth after a successful refresh", async () => {
-    const input = await createInput();
+    const { hostAuthSet, input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
     await writeSavedAuth(input, {
       access: "expired-access",
@@ -118,11 +126,11 @@ describe("server tools auth helper", () => {
 
     await tools.supabase_list_projects.execute({}, createContext(input));
 
-    expect(input.client.auth.set).toHaveBeenCalledTimes(1);
+    expect(hostAuthSet).toHaveBeenCalledTimes(1);
   });
 
   test("clears saved auth and host auth when refresh is unauthorized", async () => {
-    const input = await createInput();
+    const { input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
     await writeSavedAuth(input, {
       access: "expired-access",
@@ -169,7 +177,7 @@ describe("server tools auth helper", () => {
   });
 
   test("uses persisted plugin-owned auth for management API requests when access is still valid", async () => {
-    const input = await createInput();
+    const { input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
     await writeSavedAuth(input, {
       access: "saved-access",
@@ -207,7 +215,7 @@ describe("server tools auth helper", () => {
   });
 
   test("refreshes expired persisted auth through the broker before calling the management API", async () => {
-    const input = await createInput();
+    const { hostAuthSet, input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
     await writeSavedAuth(input, {
       access: "expired-access",
@@ -262,7 +270,7 @@ describe("server tools auth helper", () => {
 
     expect(result).toContain("proj_456");
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    expect(input.client.auth.set).toHaveBeenCalledTimes(1);
+    expect(hostAuthSet).toHaveBeenCalledTimes(1);
     await expect(readSavedAuth(input)).resolves.toMatchObject({
       version: 1,
       auth: {
@@ -272,8 +280,154 @@ describe("server tools auth helper", () => {
     });
   });
 
+  test("refreshes a nearly expired token before calling the management API", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "stale-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 5_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        return new Response(
+          JSON.stringify({
+            access_token: "fresh-access",
+            refresh_token: "fresh-refresh",
+            expires_in: 3600,
+            token_type: "bearer",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      expect(url).toBe("https://api.supabase.com/v1/projects");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer fresh-access",
+      });
+
+      return new Response(JSON.stringify([{ id: "proj_near" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17679,
+      },
+      { fetch: fetchMock },
+    );
+
+    const result = await tools.supabase_list_projects.execute({}, createContext(input));
+
+    expect(result).toContain("proj_near");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  test("continues with refreshed plugin auth when host auth sync fails", async () => {
+    const { hostAuthSet, input } = await createInput();
+    hostAuthSet.mockImplementationOnce(async () => {
+      throw new Error("host auth unavailable");
+    });
+
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        return new Response(
+          JSON.stringify({
+            access_token: "fresh-access",
+            refresh_token: "fresh-refresh",
+            expires_in: 3600,
+            token_type: "bearer",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(JSON.stringify([{ id: "proj_host_sync" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17680,
+      },
+      { fetch: fetchMock },
+    );
+
+    const result = await tools.supabase_list_projects.execute({}, createContext(input));
+
+    expect(result).toContain("proj_host_sync");
+    await expect(readSavedAuth(input)).resolves.toMatchObject({
+      auth: {
+        access: "fresh-access",
+        refresh: "fresh-refresh",
+      },
+    });
+  });
+
+  test("still returns reconnect guidance when host auth cleanup fails", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "expired-access",
+      refresh: "bad-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "unauthorized",
+              message: "refresh token invalid",
+            },
+          }),
+          { status: 401, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url === "http://127.0.0.1:7777/auth/supabase?directory=" + encodeURIComponent(input.directory)) {
+        throw new Error("delete failed");
+      }
+
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    await expect(
+      ensureSupabaseToolAuth(
+        input,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17681,
+        },
+        { fetch: fetchMock },
+      ),
+    ).rejects.toThrow("Supabase is not connected. Run /supabase first.");
+
+    await expect(readSavedAuth(input)).resolves.toEqual({ version: 1 });
+  });
+
   test("lists organizations for the authenticated user", async () => {
-    const input = await createInput();
+    const { input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
     await writeSavedAuth(input, {
       access: "saved-access",
@@ -311,7 +465,7 @@ describe("server tools auth helper", () => {
   });
 
   test("formats organization API failures clearly", async () => {
-    const input = await createInput();
+    const { input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
     await writeSavedAuth(input, {
       access: "saved-access",
@@ -338,7 +492,7 @@ describe("server tools auth helper", () => {
   });
 
   test("fetches project api keys for a project ref", async () => {
-    const input = await createInput();
+    const { input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
     await writeSavedAuth(input, {
       access: "saved-access",
@@ -379,7 +533,7 @@ describe("server tools auth helper", () => {
   });
 
   test("formats project api key failures clearly", async () => {
-    const input = await createInput();
+    const { input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
     await writeSavedAuth(input, {
       access: "saved-access",

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -1,3 +1,4 @@
+import type { ToolContext } from "@opencode-ai/plugin/tool";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
 import { join } from "node:path";
@@ -6,24 +7,48 @@ import { tmpdir } from "node:os";
 import {
   createSupabaseTools,
   ensureSupabaseToolAuth,
+  type SupabaseToolInput,
 } from "../src/server/tools.ts";
 import { readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
 import type { FetchLike } from "../src/shared/types.ts";
 
-type PluginLikeInput = {
-  directory: string;
-  worktree: string;
-};
+type TestPluginInput = SupabaseToolInput;
+
+type TestToolContext = Pick<
+  ToolContext,
+  "directory" | "worktree" | "abort" | "sessionID" | "messageID" | "agent" | "metadata" | "ask"
+>;
 
 const cleanupPaths: string[] = [];
 const originalBrokerUrl = process.env.OPENCODE_SUPABASE_BROKER_URL;
 
-async function createInput(): Promise<PluginLikeInput> {
+async function createInput(): Promise<TestPluginInput> {
   const root = await mkdtemp(join(tmpdir(), "opencode-supabase-tools-"));
   cleanupPaths.push(root);
-  return {
+  const input = {
+    client: {
+      auth: {
+        set: mock(async () => ({ data: true })),
+      },
+    },
     directory: join(root, "consumer"),
     worktree: root,
+    serverUrl: new URL("http://127.0.0.1:7777/"),
+  } satisfies TestPluginInput;
+
+  return input;
+}
+
+function createContext(input: TestPluginInput): TestToolContext {
+  return {
+    directory: input.directory,
+    worktree: input.worktree,
+    abort: new AbortController().signal,
+    sessionID: "session",
+    messageID: "message",
+    agent: "agent",
+    metadata: () => {},
+    ask: async () => {},
   };
 }
 
@@ -48,21 +73,112 @@ describe("server tools auth helper", () => {
           clientId: "plugin-client",
           oauthPort: 17670,
         },
-        { fetch: mock(async () => new Response("unexpected")) as never },
+        { fetch: mock(async () => new Response("unexpected")) },
       ),
-    ).rejects.toThrow("No saved Supabase auth found. Please run /supabase first.");
+    ).rejects.toThrow("Supabase is not connected. Run /supabase first.");
+  });
+
+  test("updates host auth after a successful refresh", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        return new Response(
+          JSON.stringify({
+            access_token: "fresh-access",
+            refresh_token: "fresh-refresh",
+            expires_in: 3600,
+            token_type: "bearer",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response(JSON.stringify([{ id: "proj_789" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17673,
+      },
+      { fetch: fetchMock },
+    );
+
+    await tools.supabase_list_projects.execute({}, createContext(input));
+
+    expect(input.client.auth.set).toHaveBeenCalledTimes(1);
+  });
+
+  test("clears saved auth and host auth when refresh is unauthorized", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "expired-access",
+      refresh: "bad-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "unauthorized",
+              message: "refresh token invalid",
+            },
+          }),
+          { status: 401, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url === "http://127.0.0.1:7777/auth/supabase?directory=" + encodeURIComponent(input.directory)) {
+        return new Response(JSON.stringify(true), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    await expect(
+      ensureSupabaseToolAuth(
+        input,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17674,
+        },
+        { fetch: fetchMock },
+      ),
+    ).rejects.toThrow("Supabase is not connected. Run /supabase first.");
+
+    await expect(readSavedAuth(input)).resolves.toEqual({ version: 1 });
   });
 
   test("uses persisted plugin-owned auth for management API requests when access is still valid", async () => {
     const input = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
-    await writeSavedAuth(input as never, {
+    await writeSavedAuth(input, {
       access: "saved-access",
       refresh: "saved-refresh",
       expires: Date.now() + 60_000,
     });
 
-    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
       expect(url).toBe("https://api.supabase.com/v1/projects");
       expect(init?.headers).toMatchObject({
         Authorization: "Bearer saved-access",
@@ -81,19 +197,10 @@ describe("server tools auth helper", () => {
         clientId: "plugin-client",
         oauthPort: 17671,
       },
-      { fetch: fetchMock as unknown as FetchLike },
+      { fetch: fetchMock },
     );
 
-    const result = await tools.supabase_list_projects.execute({}, {
-      directory: input.directory,
-      worktree: input.worktree,
-      abort: new AbortController().signal,
-      sessionID: "session",
-      messageID: "message",
-      agent: "agent",
-      metadata: () => {},
-      ask: async () => {},
-    });
+    const result = await tools.supabase_list_projects.execute({}, createContext(input));
 
     expect(result).toContain("proj_123");
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -102,13 +209,14 @@ describe("server tools auth helper", () => {
   test("refreshes expired persisted auth through the broker before calling the management API", async () => {
     const input = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
-    await writeSavedAuth(input as never, {
+    await writeSavedAuth(input, {
       access: "expired-access",
       refresh: "saved-refresh",
       expires: Date.now() - 1_000,
     });
 
-    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
       if (url === "https://example.com/broker/refresh") {
         expect(init?.method).toBe("POST");
         expect(JSON.parse(String(init?.body))).toEqual({
@@ -147,28 +255,153 @@ describe("server tools auth helper", () => {
         clientId: "plugin-client",
         oauthPort: 17672,
       },
-      { fetch: fetchMock as unknown as FetchLike },
+      { fetch: fetchMock },
     );
 
-    const result = await tools.supabase_list_projects.execute({}, {
-      directory: input.directory,
-      worktree: input.worktree,
-      abort: new AbortController().signal,
-      sessionID: "session",
-      messageID: "message",
-      agent: "agent",
-      metadata: () => {},
-      ask: async () => {},
-    });
+    const result = await tools.supabase_list_projects.execute({}, createContext(input));
 
     expect(result).toContain("proj_456");
     expect(fetchMock).toHaveBeenCalledTimes(2);
-    await expect(readSavedAuth(input as never)).resolves.toMatchObject({
+    expect(input.client.auth.set).toHaveBeenCalledTimes(1);
+    await expect(readSavedAuth(input)).resolves.toMatchObject({
       version: 1,
       auth: {
         access: "fresh-access",
         refresh: "fresh-refresh",
       },
     });
+  });
+
+  test("lists organizations for the authenticated user", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      expect(url).toBe("https://api.supabase.com/v1/organizations");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer saved-access",
+        Accept: "application/json",
+      });
+
+      return new Response(JSON.stringify([{ id: "org_123", name: "Acme" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17675,
+      },
+      { fetch: fetchMock },
+    );
+
+    const result = await tools.supabase_list_organizations.execute({}, createContext(input));
+
+    expect(result).toContain("org_123");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("formats organization API failures clearly", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async () => {
+      return new Response("nope", { status: 403 });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17676,
+      },
+      { fetch: fetchMock },
+    );
+
+    await expect(
+      tools.supabase_list_organizations.execute({}, createContext(input)),
+    ).rejects.toThrow("Failed to list organizations: 403 nope");
+  });
+
+  test("fetches project api keys for a project ref", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      expect(url).toBe("https://api.supabase.com/v1/projects/proj_123/api-keys");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer saved-access",
+        Accept: "application/json",
+      });
+
+      return new Response(JSON.stringify([{ api_key: "anon-key" }]), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17677,
+      },
+      { fetch: fetchMock },
+    );
+
+    const result = await tools.supabase_get_project_api_keys.execute(
+      { project_ref: "proj_123" },
+      createContext(input),
+    );
+
+    expect(result).toContain("anon-key");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("formats project api key failures clearly", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async () => {
+      return new Response("missing", { status: 404 });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17678,
+      },
+      { fetch: fetchMock },
+    );
+
+    await expect(
+      tools.supabase_get_project_api_keys.execute({ project_ref: "proj_404" }, createContext(input)),
+    ).rejects.toThrow("Failed to get API keys: 404 missing");
   });
 });


### PR DESCRIPTION
## Summary
- harden Supabase tool-time auth reuse so nearly expired tokens refresh before API calls and invalid refreshes always collapse to reconnect guidance
- keep refreshed plugin-owned auth usable even if host-auth sync is temporarily unavailable
- add `supabase_list_organizations` and `supabase_get_project_api_keys` as the next read-only Management API tools

## What Changed
- update `ensureSupabaseToolAuth(...)` in `src/server/tools.ts` to:
  - refresh tokens slightly before expiry using a small buffer
  - persist refreshed plugin-owned auth first
  - treat host auth sync as best-effort instead of a hard failure for tool execution
  - clear plugin-owned auth on invalid refresh and still return `Supabase is not connected. Run /supabase first.` even if host-auth cleanup fails
- tighten `clearHostAuth(...)` to check DELETE response status while keeping user-facing reconnect guidance normalized
- add a shared `executeSupabaseGet(...)` helper so read-only Management API tools reuse the same auth and error handling path
- add `supabase_list_organizations`
- add `supabase_get_project_api_keys`
- expand `test/server-tools.test.ts` with regression coverage for:
  - near-expiry refresh
  - host-auth sync failure after successful refresh
  - host-auth cleanup failure after invalid refresh

## Verification
- `bun test test/server-tools.test.ts`
- `bun run typecheck`
- `bun test`
- manual verification by the user:
  - `supabase_list_organizations` works against real Supabase auth
  - `supabase_get_project_api_keys` works against real Supabase auth

## Example
After connecting with `/supabase`, the assistant can now call:

```text
supabase_list_organizations
supabase_get_project_api_keys { project_ref: "your-project-ref" }
```

## Warnings
- this PR does not yet add `supabase_create_project` or the thin `supabase_login` alias
- `/supabase` remains the only real login UX; server tools still return guidance instead of opening browser or showing toasts
- refresh stays broker-only; this change does not bypass the broker or add custom routes

## Relevant Context
- `PLAN.md` - Phase 4 / Task 9
- `docs/supabase-oauth-broker-contract.md`