### PR TITLE
feat(server): add supabase_create_project, supabase_login, and fix password crypto

### DIFF
--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -50,9 +50,12 @@ function isRefreshNeeded(auth: SavedAuth) {
 }
 
 function generateRandomString(length: number) {
-  return Array.from(crypto.getRandomValues(new Uint8Array(length)), (value) =>
-    (value % 36).toString(36),
-  ).join("");
+  const bytes = crypto.getRandomValues(new Uint8Array(length));
+  return btoa(String.fromCharCode(...bytes))
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/, "")
+    .slice(0, length);
 }
 
 async function executeSupabaseRequest(

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -49,12 +49,19 @@ function isRefreshNeeded(auth: SavedAuth) {
   return auth.expires <= Date.now() + REFRESH_BUFFER_MS;
 }
 
-async function executeSupabaseGet(
+function generateRandomString(length: number) {
+  return Array.from(crypto.getRandomValues(new Uint8Array(length)), (value) =>
+    (value % 36).toString(36),
+  ).join("");
+}
+
+async function executeSupabaseRequest(
   input: SupabaseToolInput,
   options: PluginOptions | undefined,
   deps: ToolDeps,
   path: string,
   errorLabel: string,
+  init?: RequestInit,
 ) {
   const config = readSupabaseConfig(options);
   const auth = await ensureSupabaseToolAuth(input, options, deps);
@@ -62,7 +69,7 @@ async function executeSupabaseGet(
     config,
     auth.access,
     path,
-    undefined,
+    init,
     deps.fetch,
   );
 
@@ -72,6 +79,16 @@ async function executeSupabaseGet(
   }
 
   return JSON.stringify(await response.json(), null, 2);
+}
+
+async function executeSupabaseGet(
+  input: SupabaseToolInput,
+  options: PluginOptions | undefined,
+  deps: ToolDeps,
+  path: string,
+  errorLabel: string,
+) {
+  return executeSupabaseRequest(input, options, deps, path, errorLabel);
 }
 
 async function setHostAuth(
@@ -184,6 +201,41 @@ export function createSupabaseTools(
           `/projects/${args.project_ref}/api-keys`,
           "get API keys",
         );
+      },
+    }),
+    supabase_create_project: tool({
+      description: "Create a new Supabase project in an organization.",
+      args: {
+        organization_id: tool.schema.string().describe("Organization ID to create the project in"),
+        name: tool.schema.string().describe("Project name"),
+        region: tool.schema.string().describe("Database region").optional(),
+        db_pass: tool.schema.string().describe("Database password").optional(),
+      },
+      async execute(args, _context: SupabaseToolContext) {
+        return executeSupabaseRequest(
+          input,
+          options,
+          deps,
+          "/projects",
+          "create project",
+          {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({
+              organization_id: args.organization_id,
+              name: args.name,
+              region: args.region ?? "us-east-1",
+              db_pass: args.db_pass ?? generateRandomString(32),
+            }),
+          },
+        );
+      },
+    }),
+    supabase_login: tool({
+      description: "Explain how to connect Supabase in the TUI.",
+      args: {},
+      async execute(_args, _context: SupabaseToolContext) {
+        return "Supabase login must be completed in the TUI. Run /supabase first.";
       },
     }),
   };

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -558,4 +558,150 @@ describe("server tools auth helper", () => {
       tools.supabase_get_project_api_keys.execute({ project_ref: "proj_404" }, createContext(input)),
     ).rejects.toThrow("Failed to get API keys: 404 missing");
   });
+
+  test("creates a project with default region and generated db password", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      expect(url).toBe("https://api.supabase.com/v1/projects");
+      expect(init?.method).toBe("POST");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer saved-access",
+        Accept: "application/json",
+        "Content-Type": "application/json",
+      });
+
+      const body = JSON.parse(String(init?.body)) as {
+        organization_id: string;
+        name: string;
+        region: string;
+        db_pass: string;
+      };
+      expect(body.organization_id).toBe("org_123");
+      expect(body.name).toBe("demo-project");
+      expect(body.region).toBe("us-east-1");
+      expect(body.db_pass.length).toBeGreaterThanOrEqual(24);
+
+      return new Response(JSON.stringify({ id: "proj_new", name: "demo-project" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17682,
+      },
+      { fetch: fetchMock },
+    );
+
+    const result = await tools.supabase_create_project.execute(
+      { organization_id: "org_123", name: "demo-project" },
+      createContext(input),
+    );
+
+    expect(result).toContain("proj_new");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("creates a project with provided region and db password", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (_request, init) => {
+      const body = JSON.parse(String(init?.body)) as {
+        organization_id: string;
+        name: string;
+        region: string;
+        db_pass: string;
+      };
+      expect(body).toEqual({
+        organization_id: "org_999",
+        name: "named-project",
+        region: "eu-west-1",
+        db_pass: "secret-pass",
+      });
+
+      return new Response(JSON.stringify({ id: "proj_custom" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17683,
+      },
+      { fetch: fetchMock },
+    );
+
+    const result = await tools.supabase_create_project.execute(
+      {
+        organization_id: "org_999",
+        name: "named-project",
+        region: "eu-west-1",
+        db_pass: "secret-pass",
+      },
+      createContext(input),
+    );
+
+    expect(result).toContain("proj_custom");
+  });
+
+  test("formats create project failures clearly", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async () => new Response("bad request", { status: 400 }));
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17684,
+      },
+      { fetch: fetchMock },
+    );
+
+    await expect(
+      tools.supabase_create_project.execute(
+        { organization_id: "org_123", name: "bad-project" },
+        createContext(input),
+      ),
+    ).rejects.toThrow("Failed to create project: 400 bad request");
+  });
+
+  test("supabase_login returns TUI guidance", async () => {
+    const { input } = await createInput();
+
+    const tools = createSupabaseTools(input, {
+      clientId: "plugin-client",
+      oauthPort: 17685,
+    });
+
+    await expect(tools.supabase_login.execute({}, createContext(input))).resolves.toBe(
+      "Supabase login must be completed in the TUI. Run /supabase first.",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add `supabase_create_project` as the first mutating Supabase Management API tool
- add `supabase_login` as a guidance-only alias that tells users to run `/supabase` in the TUI
- fix `generateRandomString` to use base64url-encoded random bytes instead of modulo-biased `value % 36`

## What Changed
- add `supabase_create_project` in `src/server/tools.ts` with args: `organization_id`, `name`, `region` (optional, default `us-east-1`), `db_pass` (optional, auto-generated)
- add `supabase_login` as a thin guidance tool returning `Supabase login must be completed in the TUI. Run /supabase first.`
- replace the modulo-biased password generator with `btoa` + base64url encoding for uniform entropy distribution
- refactor `executeSupabaseGet` into shared `executeSupabaseRequest` so POST and GET tools reuse the same auth and error handling path
- add tests for: create-project defaults, explicit region/password, error formatting, and login guidance response

## Verification
- `bun test test/server-tools.test.ts` — 16 pass
- `bun run typecheck` — pass
- `bun test` — 60 pass, 0 fail

## Example
After connecting with `/supabase`, the assistant can now call:

```text
supabase_create_project { organization_id: "org_abc", name: "my-project" }
supabase_create_project { organization_id: "org_abc", name: "eu-project", region: "eu-west-1" }
supabase_login
```

`supabase_create_project` auto-generates a 32-character base64url password when `db_pass` is omitted.

## Warnings
- `supabase_login` does **not** start OAuth or open a browser; it only returns guidance text
- `/supabase` remains the only real login flow
- `supabase_create_project` mutates state — use with care against real organizations

## Relevant Context
- `PLAN.md` — Phase 4 / Task 9
- `docs/supabase-oauth-broker-contract.md`