### PR TITLE
feat: Add default broker URL and make it optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ export OPENCODE_SUPABASE_OAUTH_PORT=14589
 
 Notes:
 
-- `OPENCODE_SUPABASE_BROKER_URL` is required. There is intentionally no built-in placeholder default.
+- `OPENCODE_SUPABASE_BROKER_URL` is optional. If not provided, defaults to the official OpenCode broker.
 - `OPENCODE_SUPABASE_OAUTH_CLIENT_ID` must match the OAuth app configured for the broker.
 - `OPENCODE_SUPABASE_OAUTH_PORT` controls the local callback URL the plugin listens on.
 - The callback path is `/auth/callback`, so the full local callback URL is `http://localhost:<port>/auth/callback`.
@@ -191,7 +191,7 @@ https://<project-ref>.supabase.co/functions/v1/opencode-supabase-broker/exchange
 https://<project-ref>.supabase.co/functions/v1/opencode-supabase-broker/refresh
 ```
 
-The plugin currently requires a real broker base URL to be configured through `OPENCODE_SUPABASE_BROKER_URL`.
+The plugin uses the official OpenCode broker by default. Override via `OPENCODE_SUPABASE_BROKER_URL` if self-hosting.
 
 ### Request and response shapes
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -73,7 +73,7 @@ export OPENCODE_SUPABASE_OAUTH_PORT=14589
 
 Notes:
 
-- `OPENCODE_SUPABASE_BROKER_URL` is required.
+- `OPENCODE_SUPABASE_BROKER_URL` is optional. If not provided, defaults to the official OpenCode broker.
 - `OPENCODE_SUPABASE_OAUTH_CLIENT_ID` must match the OAuth app used by the broker.
 - `OPENCODE_SUPABASE_OAUTH_PORT` controls the local callback listener.
 - The callback path is `/auth/callback`.

--- a/TODO.md
+++ b/TODO.md
@@ -30,18 +30,18 @@ This branch provides functional OAuth plumbing and broker integration. The items
 
 ## Productize config defaults
 
-**Current state:** Requires manual configuration of `OPENCODE_SUPABASE_OAUTH_CLIENT_ID` and `OPENCODE_SUPABASE_BROKER_URL`.
+**Current state:** Only `OPENCODE_SUPABASE_OAUTH_CLIENT_ID` requires manual configuration. `OPENCODE_SUPABASE_BROKER_URL` now has a default pointing to the official OpenCode broker.
 
 **Issue:** Not turnkey for end users; still scaffold/developer setup.
 
-**Solution options:**
-- Add official/default broker URL
+**Remaining solution options:**
 - Add built-in public client ID managed by OpenCode
 - Or explicitly document this as internal/dev-only for now
 
 **Files to modify:**
-- `src/shared/cfg.ts` (lines 45, 52)
-- `README.md` (lines 137-148)
+- `src/shared/cfg.ts` (line 46)
+- `README.md` (line 147)
+- `TESTING.md` (line 76)
 
 ## Implement remaining tool surface
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,5 +1,6 @@
 export const DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL = "https://api.supabase.com/v1/oauth/authorize";
 export const DEFAULT_SUPABASE_API_BASE_URL = "https://api.supabase.com/v1";
+export const DEFAULT_SUPABASE_BROKER_URL = "https://iaoxncwzemnfxcdwakzb.supabase.co/functions/v1/opencode-supabase-broker";
 
 import type { FetchLike, SupabaseSharedConfig } from "./types.ts";
 

--- a/src/shared/cfg.ts
+++ b/src/shared/cfg.ts
@@ -2,12 +2,17 @@ import type { PluginOptions } from "@opencode-ai/plugin";
 
 import {
   DEFAULT_SUPABASE_API_BASE_URL,
+  DEFAULT_SUPABASE_BROKER_URL,
   DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL,
 } from "./api.ts";
 import type { SupabaseEnv, SupabaseSharedConfig } from "./types.ts";
 
 function readStringOption(options: PluginOptions | undefined, key: string) {
   const value = options?.[key];
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function readEnvString(value: string | undefined): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
@@ -49,7 +54,8 @@ export function readSupabaseConfig(
   const oauthPort = requirePort(
     readPortOption(options, "oauthPort") ?? env.OPENCODE_SUPABASE_OAUTH_PORT,
   );
-  const brokerBaseUrl = requireString(env.OPENCODE_SUPABASE_BROKER_URL, "brokerBaseUrl");
+  const brokerBaseUrl =
+    readStringOption(options, "brokerBaseUrl") ?? readEnvString(env.OPENCODE_SUPABASE_BROKER_URL) ?? DEFAULT_SUPABASE_BROKER_URL;
 
   return {
     clientId,

--- a/test/shared-modules.test.ts
+++ b/test/shared-modules.test.ts
@@ -31,7 +31,7 @@ describe("shared config", () => {
     });
   });
 
-  test("ignores brokerBaseUrl in plugin options", () => {
+  test("respects brokerBaseUrl in plugin options over env", () => {
     const config = readSupabaseConfig(
       {
         clientId: "plugin-client",
@@ -43,7 +43,7 @@ describe("shared config", () => {
       },
     );
 
-    expect(config.brokerBaseUrl).toBe("https://example.com/env-broker");
+    expect(config.brokerBaseUrl).toBe("https://example.com/plugin-broker");
   });
 
   test("reads values from env when plugin options are absent", () => {
@@ -75,16 +75,16 @@ describe("shared config", () => {
     ).toThrow("Missing required Supabase config: clientId");
   });
 
-  test("fails fast when broker base url is missing", () => {
-    expect(() =>
-      readSupabaseConfig(
-        {
-          clientId: "plugin-client",
-          oauthPort: 1456,
-        },
-        {},
-      ),
-    ).toThrow("Missing required Supabase config: brokerBaseUrl");
+  test("uses default broker base url when not provided", () => {
+    const config = readSupabaseConfig(
+      {
+        clientId: "plugin-client",
+        oauthPort: 1456,
+      },
+      {},
+    );
+
+    expect(config.brokerBaseUrl).toBe("https://iaoxncwzemnfxcdwakzb.supabase.co/functions/v1/opencode-supabase-broker");
   });
 
   test("fails fast when oauth port is missing or invalid", () => {


### PR DESCRIPTION
## Summary
- Add `DEFAULT_SUPABASE_BROKER_URL` constant pointing to deployed broker (iaoxncwzemnfxcdwakzb)
- Add `readEnvString` helper to treat empty strings as undefined for env vars
- Update `brokerBaseUrl` resolution: plugin options > env var > default URL
- Update documentation (README, TESTING, TODO) to reflect broker URL is now optional
- Fix tests to match new behavior (respect plugin options, use default when missing)

## Test Plan
- [x] All 60 tests pass
- [x] Typecheck passes
- [x] Broker URL correctly falls back to default when env var is empty/undefined