### PR TITLE
chore: prepare package for npm publish

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,22 @@
+# Files to exclude from npm publish
+
+# Development files
+test/
+docs/
+supabase/
+PLAN.md
+TODO.md
+TESTING.md
+CLAUDE.md
+AGENTS.md
+CLAUDE.md
+
+# Config files (not needed for consumers)
+.gitignore
+.mise.toml
+
+# Build artifacts (none for this TS-only package)
+# node_modules is auto-excluded by npm
+
+# Screenshots / images
+*.png

--- a/package.json
+++ b/package.json
@@ -1,13 +1,23 @@
 {
   "name": "opencode-supabase",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "type": "module",
+  "description": "OpenCode plugin for Supabase integration with server and TUI components",
+  "license": "Apache-2.0",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/jumski/opencode-supabase.git"
+  },
   "main": "./index.ts",
-  "private": true,
   "exports": {
     "./server": "./src/server/index.ts",
     "./tui": "./src/tui/index.tsx"
   },
+  "files": [
+    "src/",
+    "index.ts",
+    "README.md"
+  ],
   "oc-plugin": [
     "server",
     "tui"


### PR DESCRIPTION
## Summary

Prepares the package for publication to npm registry.

## Changes

- Remove \`"private": true\` from package.json
- Add npm metadata (license: Apache-2.0, repository URL, description)
- Set version to 0.0.1
- Add \`files\` array to control what gets published (src/, index.ts, README.md)
- Create .npmignore as backup filter for development files

## Publishing

After merging, the package can be published with:
\`\`\`bash
npm login
npm publish --access public
\`\`\`

## Notes

- Package publishes TypeScript source files directly (OpenCode-specific)
- Test files, docs, and supabase/ edge function excluded from publish