### PR TITLE
fix: add default clientId and oauthPort for zero-config setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-supabase",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "type": "module",
   "description": "OpenCode plugin for Supabase integration with server and TUI components",
   "license": "Apache-2.0",

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,6 +1,8 @@
 export const DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL = "https://api.supabase.com/v1/oauth/authorize";
 export const DEFAULT_SUPABASE_API_BASE_URL = "https://api.supabase.com/v1";
 export const DEFAULT_SUPABASE_BROKER_URL = "https://iaoxncwzemnfxcdwakzb.supabase.co/functions/v1/opencode-supabase-broker";
+export const DEFAULT_SUPABASE_OAUTH_CLIENT_ID = "80c76733-1b96-424b-976b-5c2977c72008";
+export const DEFAULT_SUPABASE_OAUTH_PORT = 14589;
 
 import type { FetchLike, SupabaseSharedConfig } from "./types.ts";
 

--- a/src/shared/cfg.ts
+++ b/src/shared/cfg.ts
@@ -4,6 +4,8 @@ import {
   DEFAULT_SUPABASE_API_BASE_URL,
   DEFAULT_SUPABASE_BROKER_URL,
   DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL,
+  DEFAULT_SUPABASE_OAUTH_CLIENT_ID,
+  DEFAULT_SUPABASE_OAUTH_PORT,
 } from "./api.ts";
 import type { SupabaseEnv, SupabaseSharedConfig } from "./types.ts";
 
@@ -23,13 +25,6 @@ function readPortOption(options: PluginOptions | undefined, key: string) {
   return undefined;
 }
 
-function requireString(value: string | undefined, key: string) {
-  if (!value) {
-    throw new Error(`Missing required Supabase config: ${key}`);
-  }
-  return value;
-}
-
 function requirePort(value: number | string | undefined) {
   if (value === undefined) {
     throw new Error("Missing required Supabase config: oauthPort");
@@ -47,15 +42,19 @@ export function readSupabaseConfig(
   options: PluginOptions | undefined,
   env: SupabaseEnv = process.env,
 ): SupabaseSharedConfig {
-  const clientId = requireString(
-    readStringOption(options, "clientId") ?? env.OPENCODE_SUPABASE_OAUTH_CLIENT_ID,
-    "clientId",
-  );
+  const clientId =
+    readStringOption(options, "clientId") ??
+    readEnvString(env.OPENCODE_SUPABASE_OAUTH_CLIENT_ID) ??
+    DEFAULT_SUPABASE_OAUTH_CLIENT_ID;
   const oauthPort = requirePort(
-    readPortOption(options, "oauthPort") ?? env.OPENCODE_SUPABASE_OAUTH_PORT,
+    readPortOption(options, "oauthPort") ??
+    env.OPENCODE_SUPABASE_OAUTH_PORT ??
+    DEFAULT_SUPABASE_OAUTH_PORT,
   );
   const brokerBaseUrl =
-    readStringOption(options, "brokerBaseUrl") ?? readEnvString(env.OPENCODE_SUPABASE_BROKER_URL) ?? DEFAULT_SUPABASE_BROKER_URL;
+    readStringOption(options, "brokerBaseUrl") ??
+    readEnvString(env.OPENCODE_SUPABASE_BROKER_URL) ??
+    DEFAULT_SUPABASE_BROKER_URL;
 
   return {
     clientId,

--- a/test/shared-modules.test.ts
+++ b/test/shared-modules.test.ts
@@ -5,7 +5,12 @@ import {
   exchangeCodeThroughBroker,
   refreshTokenThroughBroker,
 } from "../src/shared/broker.ts";
-import { DEFAULT_SUPABASE_API_BASE_URL, DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL } from "../src/shared/api.ts";
+import {
+  DEFAULT_SUPABASE_API_BASE_URL,
+  DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL,
+  DEFAULT_SUPABASE_OAUTH_CLIENT_ID,
+  DEFAULT_SUPABASE_OAUTH_PORT,
+} from "../src/shared/api.ts";
 import { readSupabaseConfig } from "../src/shared/cfg.ts";
 import { buildAuthorizeUrl } from "../src/shared/oauth.ts";
 import type { FetchLike } from "../src/shared/types.ts";


### PR DESCRIPTION
## Summary

Previously, the Supabase plugin required users to set `OPENCODE_SUPABASE_OAUTH_CLIENT_ID` and `OPENCODE_SUPABASE_OAUTH_PORT` environment variables before running `/supabase`. This caused a confusing "Failed to start OAuth authorization" error when these were missing.

## Changes

- Added `DEFAULT_SUPABASE_OAUTH_CLIENT_ID` and `DEFAULT_SUPABASE_OAUTH_PORT` constants in `src/shared/api.ts`
- Updated `readSupabaseConfig()` to fall back to defaults when env vars or plugin options are absent
- Removed the `requireString()` helper that threw on missing `clientId`
- Updated tests to reflect new behavior
- Bumped version to 0.0.3

## Behavior Change

**Before:** Plugin throws error if `OPENCODE_SUPABASE_OAUTH_CLIENT_ID` or `OPENCODE_SUPABASE_OAUTH_PORT` not set
**After:** Plugin uses sensible defaults, allowing zero-config setup

## Test Updates

- `shared-modules.test.ts`: Updated imports and adjusted expectations for the new default behavior

## Verification

Run tests with:
```bash
bun test
```

Note: The test updates account for the new behavior where missing config now falls back to defaults instead of throwing.