### PR TITLE
feat(logging): add opencode debug traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,16 @@ Launch `opencode` in your project, then run:
 
 Connect your account and ask your agent about Supabase capabilities.
 
+## Debug Logging
+
+If you hit auth or tool errors and need logs for an issue, run OpenCode like this and share `opencode-supabase-debug.log`:
+
+```bash
+opencode --log-level DEBUG --print-logs 2>opencode-supabase-debug.log
+```
+
+Without `--print-logs`, OpenCode writes logs to its default log directory, documented as `~/.local/share/opencode/log/` on macOS/Linux and `%USERPROFILE%\.local\share\opencode\log` on Windows.
+
 ## Available today
 
 - **Connect** your Supabase account from OpenCode

--- a/README.md
+++ b/README.md
@@ -22,13 +22,18 @@ Connect your account and ask your agent about Supabase capabilities.
 
 ## Debug Logging
 
-If you hit auth or tool errors and need logs for an issue, run OpenCode like this and share `opencode-supabase-debug.log`:
+If you hit auth or tool errors and need logs for an issue, collect the newest OpenCode session log from its default log directory:
+
+- macOS/Linux: `~/.local/share/opencode/log/`
+- Windows: `%USERPROFILE%\.local\share\opencode\log`
+
+Run OpenCode with debug logging enabled while reproducing the problem:
 
 ```bash
-opencode --log-level DEBUG --print-logs 2>opencode-supabase-debug.log
+opencode --log-level DEBUG --print-logs
 ```
 
-Without `--print-logs`, OpenCode writes logs to its default log directory, documented as `~/.local/share/opencode/log/` on macOS/Linux and `%USERPROFILE%\.local\share\opencode\log` on Windows.
+Then share that newest session log file in the issue. In our testing, the session log file is more reliable than redirecting `stderr` with `2>` for capturing plugin activity.
 
 ## Available today
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-supabase",
-  "version": "0.0.4-alpha.1",
+  "version": "0.0.4",
   "type": "module",
   "description": "OpenCode plugin for Supabase integration with server and TUI components",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "opencode-supabase",
-  "version": "0.0.3",
+  "version": "0.0.4-alpha.1",
   "type": "module",
   "description": "OpenCode plugin for Supabase integration with server and TUI components",
   "license": "Apache-2.0",

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -27,6 +27,7 @@ type PendingAuth = {
 type AuthDeps = {
   fetch?: FetchLike;
   logger?: SupabaseLogger;
+  setCallbackTimeout?: typeof setTimeout;
 };
 
 let server: ReturnType<typeof Bun.serve> | undefined;
@@ -109,6 +110,9 @@ async function ensureServer(
       if (error) {
         clearTimeout(pending.timeout);
         pendingAuths.delete(state);
+        await deps.logger?.error("supabase auth failed", {
+          reason: "provider_denied",
+        });
         pending.reject(new Error(errorDescription || error));
         return new Response(htmlError(errorDescription || error), {
           headers: { "Content-Type": "text/html" },
@@ -119,6 +123,9 @@ async function ensureServer(
       if (!code) {
         clearTimeout(pending.timeout);
         pendingAuths.delete(state);
+        await deps.logger?.error("supabase auth failed", {
+          reason: "missing_code",
+        });
         pending.reject(new Error("Missing authorization code"));
         return new Response(htmlError("Missing authorization code"), {
           status: 400,
@@ -180,11 +187,20 @@ async function ensureServer(
   serverPort = port;
 }
 
-function waitForCallback(state: string, codeVerifier: string, redirectUri: string) {
+function waitForCallback(
+  state: string,
+  codeVerifier: string,
+  redirectUri: string,
+  deps: AuthDeps,
+) {
   return new Promise<{ tokens: SupabaseTokenResponse; expires: number }>((resolve, reject) => {
-    const timeout = setTimeout(() => {
+    const scheduleTimeout = deps.setCallbackTimeout ?? setTimeout;
+    const timeout = scheduleTimeout(() => {
       if (!pendingAuths.has(state)) return;
       pendingAuths.delete(state);
+      void deps.logger?.error("supabase auth callback timed out", {
+        reason: "timeout",
+      });
       reject(new Error("OAuth callback timeout - authorization took too long"));
     }, CALLBACK_TIMEOUT_MS);
 
@@ -219,7 +235,7 @@ export function createSupabaseAuth(
           const pkce = await generatePKCE();
           const state = generateState();
           const redirectUri = callbackUrl(config.oauthPort);
-          const callbackPromise = waitForCallback(state, pkce.verifier, redirectUri);
+          const callbackPromise = waitForCallback(state, pkce.verifier, redirectUri, deps);
 
           return {
             url: buildAuthorizeUrl(config, redirectUri, pkce, state),

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -7,6 +7,7 @@ import {
   type BrokerConfig,
 } from "../shared/broker.ts";
 import { readSupabaseConfig } from "../shared/cfg.ts";
+import type { SupabaseLogger } from "../shared/log.ts";
 import { buildAuthorizeUrl, generatePKCE, generateState } from "../shared/oauth.ts";
 import type { FetchLike, SupabaseTokenResponse } from "../shared/types.ts";
 import { HTML_SUCCESS, htmlError } from "./auth-html.ts";
@@ -25,6 +26,7 @@ type PendingAuth = {
 
 type AuthDeps = {
   fetch?: FetchLike;
+  logger?: SupabaseLogger;
 };
 
 let server: ReturnType<typeof Bun.serve> | undefined;
@@ -69,6 +71,10 @@ async function ensureServer(
     baseUrl: config.brokerBaseUrl,
   };
 
+  await deps.logger?.info("supabase callback server started", {
+    port,
+  });
+
   server = Bun.serve({
     port,
     async fetch(req) {
@@ -78,6 +84,11 @@ async function ensureServer(
       }
 
       const state = url.searchParams.get("state");
+      await deps.logger?.debug("supabase auth callback received", {
+        has_state: Boolean(state),
+        has_code: Boolean(url.searchParams.get("code")),
+        has_error: Boolean(url.searchParams.get("error")),
+      });
       if (!state) {
         return new Response(htmlError("Missing required state parameter - potential CSRF attack"), {
           status: 400,
@@ -127,6 +138,7 @@ async function ensureServer(
             code_verifier: pending.codeVerifier,
           },
           deps.fetch,
+          deps.logger,
         );
 
         const expires = Date.now() + (tokens.expires_in || 3600) * 1000;
@@ -138,6 +150,10 @@ async function ensureServer(
 
         pending.resolve({ tokens, expires });
 
+        await deps.logger?.info("supabase auth completed", {
+          status: "success",
+        });
+
         return new Response(HTML_SUCCESS, {
           headers: { "Content-Type": "text/html" },
         });
@@ -145,6 +161,11 @@ async function ensureServer(
         const errorMessage = cause instanceof BrokerClientError
           ? `Authorization failed: ${cause.message}`
           : "Authorization failed";
+
+        await deps.logger?.error("supabase auth failed", {
+          status: cause instanceof BrokerClientError ? cause.status : 400,
+          broker_error: cause instanceof BrokerClientError,
+        });
 
         pending.reject(cause instanceof Error ? cause : new Error(String(cause)));
 
@@ -192,6 +213,9 @@ export function createSupabaseAuth(
         label: "Supabase",
         async authorize() {
           await ensureServer(config.oauthPort, config, input, deps);
+          await deps.logger?.info("supabase auth started", {
+            port: config.oauthPort,
+          });
           const pkce = await generatePKCE();
           const state = generateState();
           const redirectUri = callbackUrl(config.oauthPort);

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,12 +1,12 @@
 import type { Plugin } from "@opencode-ai/plugin";
 
-import { createSupabaseLogger } from "../shared/log.ts";
+import { createServerLogWriter, createSupabaseLogger } from "../shared/log.ts";
 import { createSupabaseAuth } from "./auth.ts";
 import { createSupabaseTools } from "./tools.ts";
 
 const server: Plugin = async (input, options) => {
   const logger = createSupabaseLogger({
-    write: (entry) => input.client.app.log(entry as any),
+    write: createServerLogWriter(input.client),
   });
 
   return {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,12 +1,17 @@
 import type { Plugin } from "@opencode-ai/plugin";
 
+import { createSupabaseLogger } from "../shared/log.ts";
 import { createSupabaseAuth } from "./auth.ts";
 import { createSupabaseTools } from "./tools.ts";
 
 const server: Plugin = async (input, options) => {
+  const logger = createSupabaseLogger({
+    write: (entry) => input.client.app.log(entry as any),
+  });
+
   return {
-    auth: createSupabaseAuth(input, options),
-    tool: createSupabaseTools(input, options),
+    auth: createSupabaseAuth(input, options, { logger }),
+    tool: createSupabaseTools(input, options, { logger }),
   };
 };
 

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -8,11 +8,13 @@ import {
 } from "../shared/broker.ts";
 import { supabaseManagementApiFetch } from "../shared/api.ts";
 import { readSupabaseConfig } from "../shared/cfg.ts";
+import type { SupabaseLogger } from "../shared/log.ts";
 import type { FetchLike } from "../shared/types.ts";
 import { clearSavedAuth, readSavedAuth, writeSavedAuth, type SavedAuth } from "./store.ts";
 
 type ToolDeps = {
   fetch?: FetchLike;
+  logger?: SupabaseLogger;
 };
 
 type HostAuthWriter = {
@@ -58,14 +60,31 @@ function generateRandomString(length: number) {
     .slice(0, length);
 }
 
+function sanitizeToolArgs(name: string, args: Record<string, unknown>) {
+  const next = { ...args };
+  if (name === "supabase_create_project" && typeof next.db_pass === "string") {
+    next.db_pass = "[redacted]";
+  }
+  return next;
+}
+
 async function executeSupabaseRequest(
   input: SupabaseToolInput,
   options: PluginOptions | undefined,
   deps: ToolDeps,
+  toolName: string,
+  context: SupabaseToolContext,
   path: string,
   errorLabel: string,
   init?: RequestInit,
 ) {
+  const startedAt = Date.now();
+  await deps.logger?.info("supabase tool started", {
+    tool: toolName,
+    sessionID: context.sessionID,
+    messageID: context.messageID,
+    agent: context.agent,
+  });
   const config = readSupabaseConfig(options);
   const auth = await ensureSupabaseToolAuth(input, options, deps);
   const response = await supabaseManagementApiFetch(
@@ -76,10 +95,26 @@ async function executeSupabaseRequest(
     deps.fetch,
   );
 
+  await deps.logger?.debug("supabase api response received", {
+    tool: toolName,
+    path,
+    status: response.status,
+  });
+
   if (!response.ok) {
     const body = await response.text().catch(() => "");
+    await deps.logger?.error("supabase tool failed", {
+      tool: toolName,
+      path,
+      status: response.status,
+    });
     throw new Error(`Failed to ${errorLabel}: ${response.status} ${body}`.trim());
   }
+
+  await deps.logger?.info("supabase tool completed", {
+    tool: toolName,
+    duration_ms: Date.now() - startedAt,
+  });
 
   return JSON.stringify(await response.json(), null, 2);
 }
@@ -88,10 +123,12 @@ async function executeSupabaseGet(
   input: SupabaseToolInput,
   options: PluginOptions | undefined,
   deps: ToolDeps,
+  toolName: string,
+  context: SupabaseToolContext,
   path: string,
   errorLabel: string,
 ) {
-  return executeSupabaseRequest(input, options, deps, path, errorLabel);
+  return executeSupabaseRequest(input, options, deps, toolName, context, path, errorLabel);
 }
 
 async function setHostAuth(
@@ -143,6 +180,7 @@ export async function ensureSupabaseToolAuth(
       { baseUrl: config.brokerBaseUrl },
       { refresh_token: saved.auth.refresh },
       deps.fetch,
+      deps.logger,
     );
 
     const nextAuth: SavedAuth = {
@@ -181,14 +219,30 @@ export function createSupabaseTools(
       description: "List all Supabase organizations for the authenticated user.",
       args: {},
       async execute(_args, _context: SupabaseToolContext) {
-        return executeSupabaseGet(input, options, deps, "/organizations", "list organizations");
+        return executeSupabaseGet(
+          input,
+          options,
+          deps,
+          "supabase_list_organizations",
+          _context,
+          "/organizations",
+          "list organizations",
+        );
       },
     }),
     supabase_list_projects: tool({
       description: "List all Supabase projects for the authenticated user.",
       args: {},
       async execute(_args, _context: SupabaseToolContext) {
-        return executeSupabaseGet(input, options, deps, "/projects", "list projects");
+        return executeSupabaseGet(
+          input,
+          options,
+          deps,
+          "supabase_list_projects",
+          _context,
+          "/projects",
+          "list projects",
+        );
       },
     }),
     supabase_get_project_api_keys: tool({
@@ -201,6 +255,8 @@ export function createSupabaseTools(
           input,
           options,
           deps,
+          "supabase_get_project_api_keys",
+          _context,
           `/projects/${args.project_ref}/api-keys`,
           "get API keys",
         );
@@ -215,10 +271,16 @@ export function createSupabaseTools(
         db_pass: tool.schema.string().describe("Database password").optional(),
       },
       async execute(args, _context: SupabaseToolContext) {
+        await deps.logger?.debug("supabase tool args prepared", {
+          tool: "supabase_create_project",
+          args: sanitizeToolArgs("supabase_create_project", args),
+        });
         return executeSupabaseRequest(
           input,
           options,
           deps,
+          "supabase_create_project",
+          _context,
           "/projects",
           "create project",
           {

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -85,38 +85,49 @@ async function executeSupabaseRequest(
     messageID: context.messageID,
     agent: context.agent,
   });
-  const config = readSupabaseConfig(options);
-  const auth = await ensureSupabaseToolAuth(input, options, deps);
-  const response = await supabaseManagementApiFetch(
-    config,
-    auth.access,
-    path,
-    init,
-    deps.fetch,
-  );
+  try {
+    const config = readSupabaseConfig(options);
+    const auth = await ensureSupabaseToolAuth(input, options, deps);
+    const response = await supabaseManagementApiFetch(
+      config,
+      auth.access,
+      path,
+      init,
+      deps.fetch,
+    );
 
-  await deps.logger?.debug("supabase api response received", {
-    tool: toolName,
-    path,
-    status: response.status,
-  });
-
-  if (!response.ok) {
-    const body = await response.text().catch(() => "");
-    await deps.logger?.error("supabase tool failed", {
+    await deps.logger?.debug("supabase api response received", {
       tool: toolName,
       path,
       status: response.status,
     });
-    throw new Error(`Failed to ${errorLabel}: ${response.status} ${body}`.trim());
+
+    if (!response.ok) {
+      const body = await response.text().catch(() => "");
+      await deps.logger?.error("supabase tool failed", {
+        tool: toolName,
+        path,
+        status: response.status,
+      });
+      throw new Error(`Failed to ${errorLabel}: ${response.status} ${body}`.trim());
+    }
+
+    const payload = await response.json();
+
+    await deps.logger?.info("supabase tool completed", {
+      tool: toolName,
+      duration_ms: Date.now() - startedAt,
+    });
+
+    return JSON.stringify(payload, null, 2);
+  } catch (error) {
+    await deps.logger?.error("supabase tool failed", {
+      tool: toolName,
+      path,
+      reason: error instanceof Error ? error.message : String(error),
+    });
+    throw error;
   }
-
-  await deps.logger?.info("supabase tool completed", {
-    tool: toolName,
-    duration_ms: Date.now() - startedAt,
-  });
-
-  return JSON.stringify(await response.json(), null, 2);
 }
 
 async function executeSupabaseGet(

--- a/src/shared/broker.ts
+++ b/src/shared/broker.ts
@@ -1,4 +1,5 @@
 import type { FetchLike, SupabaseTokenResponse } from "./types.ts";
+import type { SupabaseLogger } from "./log.ts";
 
 export type BrokerConfig = {
   baseUrl: string;
@@ -95,8 +96,13 @@ async function makeBrokerRequest(
   endpoint: string,
   body: unknown,
   fetchImpl: FetchLike,
+  logger?: SupabaseLogger,
 ): Promise<SupabaseTokenResponse> {
   const url = `${config.baseUrl.replace(/\/$/, "")}${endpoint}`;
+
+  await logger?.debug("supabase broker request started", {
+    endpoint,
+  });
 
   let response: Response;
 
@@ -110,6 +116,10 @@ async function makeBrokerRequest(
       body: JSON.stringify(body),
     });
   } catch (cause) {
+    await logger?.error("supabase broker request failed", {
+      endpoint,
+      status: 502,
+    });
     throw new BrokerClientError({
       code: "upstream_error",
       message: "broker request failed",
@@ -122,6 +132,10 @@ async function makeBrokerRequest(
   try {
     payload = await response.json();
   } catch {
+    await logger?.error("supabase broker response invalid", {
+      endpoint,
+      status: response.status,
+    });
     throw new BrokerClientError({
       code: "upstream_error",
       message: "broker returned an invalid response",
@@ -129,12 +143,26 @@ async function makeBrokerRequest(
     });
   }
 
+  await logger?.debug("supabase broker response received", {
+    endpoint,
+    status: response.status,
+  });
+
   if (!response.ok) {
     const errorBody = payload as Record<string, unknown> | undefined;
     const error = errorBody?.error as Record<string, unknown> | undefined;
 
     const code = (error?.code as BrokerErrorCode) || "upstream_error";
     const message = (error?.message as string) || "broker request failed";
+
+    await logger?.error(
+      endpoint === "/exchange" ? "supabase broker exchange failed" : "supabase broker refresh failed",
+      {
+        endpoint,
+        status: response.status,
+        code,
+      },
+    );
 
     throw new BrokerClientError({
       code,
@@ -150,6 +178,7 @@ export async function exchangeCodeThroughBroker(
   config: BrokerConfig,
   input: ExchangeRequest,
   fetchImpl: FetchLike = fetch,
+  logger?: SupabaseLogger,
 ): Promise<SupabaseTokenResponse> {
   return makeBrokerRequest(
     config,
@@ -160,6 +189,7 @@ export async function exchangeCodeThroughBroker(
       redirect_uri: input.redirect_uri,
     },
     fetchImpl,
+    logger,
   );
 }
 
@@ -167,6 +197,7 @@ export async function refreshTokenThroughBroker(
   config: BrokerConfig,
   input: RefreshRequest,
   fetchImpl: FetchLike = fetch,
+  logger?: SupabaseLogger,
 ): Promise<SupabaseTokenResponse> {
   return makeBrokerRequest(
     config,
@@ -175,5 +206,6 @@ export async function refreshTokenThroughBroker(
       refresh_token: input.refresh_token,
     },
     fetchImpl,
+    logger,
   );
 }

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -2,7 +2,7 @@ export type SupabaseLogLevel = "debug" | "info" | "warn" | "error";
 
 export type SupabaseLogger = ReturnType<typeof createSupabaseLogger>;
 
-type LogEntry = {
+export type LogEntry = {
   service: string;
   level: SupabaseLogLevel;
   message: string;
@@ -18,13 +18,18 @@ export function createSupabaseLogger(input: { write: LogWriter }) {
     extra?: Record<string, unknown>,
   ) {
     try {
-      await input.write({
+      const result = await input.write({
         service: "opencode-supabase",
         level,
         message,
         extra,
       });
-    } catch {}
+      if (result && typeof result === "object" && "error" in result) {
+        console.error("[opencode-supabase] host log rejected:", (result as { error: unknown }).error);
+      }
+    } catch (error) {
+      console.error("[opencode-supabase] host log failed:", error instanceof Error ? error.message : error);
+    }
   }
 
   return {
@@ -41,4 +46,12 @@ export function createSupabaseLogger(input: { write: LogWriter }) {
       return emit("error", message, extra);
     },
   };
+}
+
+export function createServerLogWriter(client: { app: { log: (input: { body: LogEntry }) => Promise<unknown> } }) {
+  return (entry: LogEntry) => client.app.log({ body: entry });
+}
+
+export function createTuiLogWriter(client: { app: { log: (input: LogEntry, options?: { throwOnError?: boolean }) => Promise<unknown> } }) {
+  return (entry: LogEntry) => client.app.log(entry, { throwOnError: true });
 }

--- a/src/shared/log.ts
+++ b/src/shared/log.ts
@@ -1,0 +1,44 @@
+export type SupabaseLogLevel = "debug" | "info" | "warn" | "error";
+
+export type SupabaseLogger = ReturnType<typeof createSupabaseLogger>;
+
+type LogEntry = {
+  service: string;
+  level: SupabaseLogLevel;
+  message: string;
+  extra?: Record<string, unknown>;
+};
+
+type LogWriter = (entry: LogEntry) => Promise<unknown>;
+
+export function createSupabaseLogger(input: { write: LogWriter }) {
+  async function emit(
+    level: SupabaseLogLevel,
+    message: string,
+    extra?: Record<string, unknown>,
+  ) {
+    try {
+      await input.write({
+        service: "opencode-supabase",
+        level,
+        message,
+        extra,
+      });
+    } catch {}
+  }
+
+  return {
+    debug(message: string, extra?: Record<string, unknown>) {
+      return emit("debug", message, extra);
+    },
+    info(message: string, extra?: Record<string, unknown>) {
+      return emit("info", message, extra);
+    },
+    warn(message: string, extra?: Record<string, unknown>) {
+      return emit("warn", message, extra);
+    },
+    error(message: string, extra?: Record<string, unknown>) {
+      return emit("error", message, extra);
+    },
+  };
+}

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -1,9 +1,12 @@
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
 import { createSignal } from "solid-js";
 
+import type { SupabaseLogger } from "../shared/log.ts";
+
 type SupabaseDialogProps = {
   api: TuiPluginApi;
   onClose: () => void;
+  logger: SupabaseLogger;
 };
 
 type OAuthState =
@@ -28,6 +31,9 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
   const startOAuth = async () => {
     try {
+      await props.logger.info("supabase auth started", {
+        phase: "authorize",
+      });
       setState({ type: "authorizing", url: "" });
 
       // Start OAuth authorization
@@ -50,7 +56,14 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       }
 
       const { url, method } = authData;
+      const safeUrl = new URL(url);
       setState({ type: "authorizing", url });
+
+      await props.logger.debug("supabase auth authorize response received", {
+        method,
+        url_origin: safeUrl.origin,
+        url_path: safeUrl.pathname,
+      });
 
       // Attempt to open browser automatically
       if (method === "auto") {
@@ -58,11 +71,13 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
           const open = await import("open");
           await open.default(url);
         } catch {
+          await props.logger.warn("supabase browser open failed");
           // Browser auto-open failed, user can click the URL manually
         }
       }
 
       setState({ type: "waiting_callback", url });
+      await props.logger.debug("supabase auth waiting for callback");
 
       // Wait for callback
       const callbackResponse = (await props.api.client.provider.oauth.callback({
@@ -79,6 +94,9 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       const callbackSucceeded = callbackResponse.data === true;
 
       if (callbackSucceeded) {
+        await props.logger.info("supabase auth completed", {
+          status: "success",
+        });
         setState({ type: "success" });
         props.api.ui.toast({
           variant: "success",
@@ -92,6 +110,9 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
     } catch (error) {
       const message =
         error instanceof Error ? error.message : "Authorization failed";
+      await props.logger.error("supabase auth failed", {
+        message,
+      });
       setState({ type: "error", message });
       props.api.ui.toast({
         variant: "error",

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,12 +1,12 @@
 import type { TuiPlugin } from "@opencode-ai/plugin/tui";
 
-import { createSupabaseLogger } from "../shared/log.ts";
+import { createSupabaseLogger, createTuiLogWriter } from "../shared/log.ts";
 import { createSupabaseCommand } from "./commands";
 import { SupabaseDialog } from "./dialog";
 
 const tui: TuiPlugin = async (api) => {
   const logger = createSupabaseLogger({
-    write: (entry) => api.client.app.log(entry),
+    write: createTuiLogWriter(api.client),
   });
 
   api.command.register(() => [

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -1,12 +1,17 @@
 import type { TuiPlugin } from "@opencode-ai/plugin/tui";
 
+import { createSupabaseLogger } from "../shared/log.ts";
 import { createSupabaseCommand } from "./commands";
 import { SupabaseDialog } from "./dialog";
 
 const tui: TuiPlugin = async (api) => {
+  const logger = createSupabaseLogger({
+    write: (entry) => api.client.app.log(entry),
+  });
+
   api.command.register(() => [
     createSupabaseCommand(() => {
-      api.ui.dialog.replace(() => SupabaseDialog({ api, onClose: () => api.ui.dialog.clear() }));
+      api.ui.dialog.replace(() => SupabaseDialog({ api, logger, onClose: () => api.ui.dialog.clear() }));
     }),
   ]);
 };

--- a/test/phase1-package-contract.test.ts
+++ b/test/phase1-package-contract.test.ts
@@ -17,8 +17,10 @@ describe("phase 1 package contract", () => {
 
   test("documents plugin install and debug log capture guidance", () => {
     expect(readme).toContain("opencode plugin opencode-supabase");
-    expect(readme).toContain("opencode --log-level DEBUG --print-logs 2>opencode-supabase-debug.log");
+    expect(readme).toContain("collect the newest OpenCode session log");
+    expect(readme).toContain("opencode --log-level DEBUG --print-logs");
     expect(readme).toContain("~/.local/share/opencode/log/");
     expect(readme).toContain("%USERPROFILE%\\.local\\share\\opencode\\log");
+    expect(readme).toContain("more reliable than redirecting `stderr` with `2>`");
   });
 });

--- a/test/phase1-package-contract.test.ts
+++ b/test/phase1-package-contract.test.ts
@@ -7,22 +7,18 @@ const packageJson = JSON.parse(
 const readme = readFileSync(new URL("../README.md", import.meta.url), "utf8");
 
 describe("phase 1 package contract", () => {
-  test("keeps the package private and exposes the dual-target exports", () => {
+  test("exposes the dual-target exports", () => {
     expect(packageJson.name).toBe("opencode-supabase");
-    expect(packageJson.private).toBe(true);
     expect(packageJson.main).toBe("./index.ts");
     expect(packageJson.exports["./server"]).toBe("./src/server/index.ts");
     expect(packageJson.exports["./tui"]).toBe("./src/tui/index.tsx");
     expect(packageJson["oc-plugin"]).toEqual(["server", "tui"]);
   });
 
-  test("documents CLI-first install with a manual config fallback", () => {
-    expect(readme).toContain("opencode plugin ../../opencode-supabase");
-    expect(readme).toContain(".opencode/opencode.jsonc");
-    expect(readme).toContain(".opencode/tui.jsonc");
-    expect(readme).toContain('"plugin": ["../../opencode-supabase"]');
-    expect(readme).toContain(
-      "resolved from inside `.opencode/`, not from the consumer repo root",
-    );
+  test("documents plugin install and debug log capture guidance", () => {
+    expect(readme).toContain("opencode plugin opencode-supabase");
+    expect(readme).toContain("opencode --log-level DEBUG --print-logs 2>opencode-supabase-debug.log");
+    expect(readme).toContain("~/.local/share/opencode/log/");
+    expect(readme).toContain("%USERPROFILE%\\.local\\share\\opencode\\log");
   });
 });

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -114,6 +114,9 @@ test("supabase dialog treats boolean callback success as connected", async () =>
       },
     },
     client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
       provider: {
         oauth: {
           authorize: () => Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } }),
@@ -123,7 +126,14 @@ test("supabase dialog treats boolean callback success as connected", async () =>
     },
   } as any;
 
-  const dialog = SupabaseDialog({ api, onClose: () => api.ui.dialog.clear() }) as {
+  const logger = {
+    debug: () => Promise.resolve(),
+    info: () => Promise.resolve(),
+    warn: () => Promise.resolve(),
+    error: () => Promise.resolve(),
+  };
+
+  const dialog = SupabaseDialog({ api, logger, onClose: () => api.ui.dialog.clear() }) as {
     onConfirm?: () => Promise<void>;
   };
 
@@ -133,5 +143,60 @@ test("supabase dialog treats boolean callback success as connected", async () =>
   expect(toasts[0]).toMatchObject({
     variant: "success",
   });
+  expect(cleared).toBe(1);
+});
+
+test("supabase dialog logs auth milestones without leaking oauth query values", async () => {
+  const appLog = [] as Array<Record<string, unknown>>;
+  let cleared = 0;
+
+  const api = {
+    ui: {
+      DialogAlert: (input: unknown) => input,
+      DialogConfirm: (input: unknown) => input,
+      toast: () => {},
+      dialog: {
+        clear: () => {
+          cleared += 1;
+        },
+      },
+    },
+    client: {
+      app: {
+        log: (input: Record<string, unknown>) => {
+          appLog.push(input);
+          return Promise.resolve(true);
+        },
+      },
+      provider: {
+        oauth: {
+          authorize: () => Promise.resolve({ data: { url: "https://example.com/auth?code=secret", instructions: "Test", method: "auto" } }),
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  } as any;
+
+  const logger = {
+    debug: (message: string, extra?: Record<string, unknown>) =>
+      api.client.app.log({ service: "opencode-supabase", level: "debug", message, extra }),
+    info: (message: string, extra?: Record<string, unknown>) =>
+      api.client.app.log({ service: "opencode-supabase", level: "info", message, extra }),
+    warn: (message: string, extra?: Record<string, unknown>) =>
+      api.client.app.log({ service: "opencode-supabase", level: "warn", message, extra }),
+    error: (message: string, extra?: Record<string, unknown>) =>
+      api.client.app.log({ service: "opencode-supabase", level: "error", message, extra }),
+  };
+
+  const dialog = SupabaseDialog({ api, logger, onClose: () => api.ui.dialog.clear() }) as {
+    onConfirm?: () => Promise<void>;
+  };
+
+  await dialog.onConfirm?.();
+
+  const serialized = JSON.stringify(appLog);
+  expect(serialized).toContain("supabase auth started");
+  expect(serialized).toContain("supabase auth completed");
+  expect(serialized).not.toContain("code=secret");
   expect(cleared).toBe(1);
 });

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -118,6 +118,64 @@ describe("server auth hook", () => {
     expect(logEntries.join(" ")).not.toContain("code-123");
   });
 
+  test("logs oauth provider denial without leaking callback values", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    const write = mock(async () => true);
+    const auth = createSupabaseAuth(
+      input as never,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17659,
+      },
+      {
+        logger: createSupabaseLogger({ write }),
+      },
+    );
+
+    const result = await auth.methods[0]!.authorize();
+    const authUrl = new URL(result.url);
+    const redirectUri = new URL(authUrl.searchParams.get("redirect_uri")!);
+    const state = authUrl.searchParams.get("state");
+
+    const pending = result.callback();
+    pending.catch(() => undefined);
+    await fetch(`${redirectUri.toString()}?error=access_denied&error_description=User%20denied&state=${state}`);
+    await expect(pending).rejects.toThrow("User denied");
+
+    const logEntries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+    expect(logEntries.some((entry) => entry.includes("supabase auth failed"))).toBe(true);
+    expect(logEntries.join(" ")).not.toContain("access_denied");
+  });
+
+  test("logs callback timeout failures", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    const write = mock(async () => true);
+    const timer = { ref() { return timer; }, unref() { return timer; } } as unknown as ReturnType<typeof setTimeout>;
+
+    const auth = createSupabaseAuth(
+      input as never,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17660,
+      },
+      {
+        logger: createSupabaseLogger({ write }),
+        setCallbackTimeout: ((callback: (...args: Array<unknown>) => void) => {
+          queueMicrotask(() => callback());
+          return timer;
+        }) as typeof setTimeout,
+      },
+    );
+
+    const result = await auth.methods[0]!.authorize();
+    await expect(result.callback()).rejects.toThrow("OAuth callback timeout - authorization took too long");
+
+    const logEntries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+    expect(logEntries.some((entry) => entry.includes("supabase auth callback timed out"))).toBe(true);
+  });
+
   test("builds an auto oauth authorize result using the plugin callback server", async () => {
     const input = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 
 import { createSupabaseAuth, stopSupabaseAuthServer } from "../src/server/auth.ts";
 import { readSavedAuth } from "../src/server/store.ts";
+import { createSupabaseLogger } from "../src/shared/log.ts";
 import type { FetchLike } from "../src/shared/types.ts";
 
 const cleanupPaths: string[] = [];
@@ -30,6 +31,93 @@ afterEach(async () => {
 });
 
 describe("server auth hook", () => {
+  test("logs auth authorize and callback completion without secrets", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    const write = mock(async () => true);
+    const auth = createSupabaseAuth(
+      input as never,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17657,
+      },
+      {
+        fetch: mock(async () =>
+          new Response(
+            JSON.stringify({
+              access_token: "access-123",
+              refresh_token: "refresh-123",
+              expires_in: 1800,
+              token_type: "bearer",
+            }),
+          ),
+        ) as never,
+        logger: createSupabaseLogger({ write }),
+      },
+    );
+
+    const result = await auth.methods[0]!.authorize();
+    const authUrl = new URL(result.url);
+    const redirectUri = new URL(authUrl.searchParams.get("redirect_uri")!);
+    const state = authUrl.searchParams.get("state");
+
+    const pending = result.callback();
+    await fetch(`${redirectUri.toString()}?code=code-123&state=${state}`);
+    await pending;
+
+    const logEntries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+
+    expect(logEntries.some((entry) => entry.includes("supabase auth started"))).toBe(true);
+    expect(logEntries.some((entry) => entry.includes("supabase auth completed"))).toBe(true);
+    expect(logEntries.join(" ")).not.toContain("code-123");
+    expect(logEntries.join(" ")).not.toContain("refresh-123");
+  });
+
+  test("logs broker failures without leaking oauth code", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    const write = mock(async () => true);
+    const auth = createSupabaseAuth(
+      input as never,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17658,
+      },
+      {
+        fetch: mock(async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                code: "invalid_request",
+                message: "redirect_uri not allowed",
+              },
+            }),
+            {
+              status: 400,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        ) as never,
+        logger: createSupabaseLogger({ write }),
+      },
+    );
+
+    const result = await auth.methods[0]!.authorize();
+    const authUrl = new URL(result.url);
+    const redirectUri = new URL(authUrl.searchParams.get("redirect_uri")!);
+    const state = authUrl.searchParams.get("state");
+
+    const pending = result.callback();
+    pending.catch(() => undefined);
+    await fetch(`${redirectUri.toString()}?code=code-123&state=${state}`);
+    await expect(pending).rejects.toThrow("redirect_uri not allowed");
+
+    const logEntries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+
+    expect(logEntries.some((entry) => entry.includes("supabase broker exchange failed"))).toBe(true);
+    expect(logEntries.join(" ")).not.toContain("code-123");
+  });
+
   test("builds an auto oauth authorize result using the plugin callback server", async () => {
     const input = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -10,6 +10,7 @@ import {
   type SupabaseToolInput,
 } from "../src/server/tools.ts";
 import { readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
+import { createSupabaseLogger } from "../src/shared/log.ts";
 import type { FetchLike } from "../src/shared/types.ts";
 
 type TestPluginInput = SupabaseToolInput;
@@ -70,6 +71,50 @@ afterEach(async () => {
 });
 
 describe("server tools auth helper", () => {
+  test("logs tool execution boundaries and redacts sensitive args", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: `access-${Date.now()}`,
+      refresh: `refresh-${Date.now()}`,
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock = mock(async () =>
+      new Response(JSON.stringify({ id: "project-1" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      }));
+    const write = mock(async () => true);
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17671,
+      },
+      {
+        fetch: fetchMock as unknown as FetchLike,
+        logger: createSupabaseLogger({ write }),
+      },
+    );
+
+    await tools.supabase_create_project.execute(
+      {
+        organization_id: "org-1",
+        name: "My Project",
+        region: "us-east-1",
+        db_pass: "super-secret-db-pass",
+      },
+      createContext(input),
+    );
+
+    const entries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+    expect(entries.some((entry) => entry.includes("supabase tool started"))).toBe(true);
+    expect(entries.some((entry) => entry.includes("supabase tool completed"))).toBe(true);
+    expect(entries.join(" ")).toContain("supabase_create_project");
+    expect(entries.join(" ")).not.toContain("super-secret-db-pass");
+  });
+
   test("fails clearly when no persisted Supabase auth exists", async () => {
     const { input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -115,6 +115,64 @@ describe("server tools auth helper", () => {
     expect(entries.join(" ")).not.toContain("super-secret-db-pass");
   });
 
+  test("logs tool auth failures and request failures", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    const write = mock(async () => true);
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17672,
+      },
+      {
+        fetch: mock(async () => new Response("unexpected")) as unknown as FetchLike,
+        logger: createSupabaseLogger({ write }),
+      },
+    );
+
+    await expect(tools.supabase_list_projects.execute({}, createContext(input))).rejects.toThrow(
+      "Supabase is not connected. Run /supabase first.",
+    );
+
+    const entries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+    expect(entries.some((entry) => entry.includes("supabase tool started"))).toBe(true);
+    expect(entries.some((entry) => entry.includes("supabase tool failed"))).toBe(true);
+  });
+
+  test("does not log tool completion when response json parsing fails", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: `access-${Date.now()}`,
+      refresh: `refresh-${Date.now()}`,
+      expires: Date.now() + 60_000,
+    });
+
+    const write = mock(async () => true);
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17675,
+      },
+      {
+        fetch: mock(async () =>
+          new Response("not-json", {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          })) as unknown as FetchLike,
+        logger: createSupabaseLogger({ write }),
+      },
+    );
+
+    await expect(tools.supabase_list_projects.execute({}, createContext(input))).rejects.toThrow();
+
+    const entries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+    expect(entries.some((entry) => entry.includes("supabase tool completed"))).toBe(false);
+    expect(entries.some((entry) => entry.includes("supabase tool failed"))).toBe(true);
+  });
+
   test("fails clearly when no persisted Supabase auth exists", async () => {
     const { input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";

--- a/test/shared-modules.test.ts
+++ b/test/shared-modules.test.ts
@@ -12,7 +12,12 @@ import {
   DEFAULT_SUPABASE_OAUTH_PORT,
 } from "../src/shared/api.ts";
 import { readSupabaseConfig } from "../src/shared/cfg.ts";
-import { createSupabaseLogger } from "../src/shared/log.ts";
+import {
+  createSupabaseLogger,
+  createServerLogWriter,
+  createTuiLogWriter,
+  type LogEntry,
+} from "../src/shared/log.ts";
 import { buildAuthorizeUrl } from "../src/shared/oauth.ts";
 import type { FetchLike } from "../src/shared/types.ts";
 
@@ -146,13 +151,79 @@ describe("shared log", () => {
     });
   });
 
-  test("swallows host logger failures", async () => {
+  test("swallows host logger failures and prints to console.error", async () => {
     const write = mock(async () => {
       throw new Error("host logger offline");
     });
     const logger = createSupabaseLogger({ write });
+    const originalError = console.error;
+    const errors: unknown[] = [];
+    console.error = (...args: unknown[]) => errors.push(...args);
 
-    await expect(logger.error("supabase auth failed")).resolves.toBeUndefined();
+    try {
+      await logger.error("supabase auth failed");
+      expect(errors.some((e) => String(e).includes("host logger offline"))).toBe(true);
+    } finally {
+      console.error = originalError;
+    }
+  });
+
+  test("detects v2 SDK error responses that do not throw", async () => {
+    const write = mock(async () => ({ error: "bad request" }));
+    const logger = createSupabaseLogger({ write });
+    const originalError = console.error;
+    const errors: unknown[] = [];
+    console.error = (...args: unknown[]) => errors.push(...args);
+
+    try {
+      await logger.info("test message");
+      expect(errors.some((e) => String(e).includes("host log rejected"))).toBe(true);
+    } finally {
+      console.error = originalError;
+    }
+  });
+});
+
+describe("server log writer", () => {
+  test("wraps log entry in body for v1 SDK", async () => {
+    const logCalls: Array<{ body: LogEntry }> = [];
+    const client = {
+      app: {
+        log: (input: { body: LogEntry }) => {
+          logCalls.push(input);
+          return Promise.resolve(true);
+        },
+      },
+    };
+
+    const write = createServerLogWriter(client);
+    const entry: LogEntry = { service: "opencode-supabase", level: "info", message: "test" };
+    await write(entry);
+
+    expect(logCalls).toHaveLength(1);
+    expect(logCalls[0]!.body).toEqual(entry);
+  });
+});
+
+describe("tui log writer", () => {
+  test("passes flat entry with throwOnError for v2 SDK", async () => {
+    const logCalls: Array<{ params: LogEntry; options: { throwOnError?: boolean } }> = [];
+    const client = {
+      app: {
+        log: (input: LogEntry, options?: { throwOnError?: boolean }) => {
+          logCalls.push({ params: input, options: options ?? { throwOnError: false } });
+          return Promise.resolve(true);
+        },
+      },
+    };
+
+    const write = createTuiLogWriter(client);
+    const entry: LogEntry = { service: "opencode-supabase", level: "info", message: "test" };
+    await write(entry);
+
+    expect(logCalls).toHaveLength(1);
+    expect(logCalls[0]!.params).toEqual(entry);
+    expect(logCalls[0]!.options.throwOnError).toBe(true);
   });
 });
 

--- a/test/shared-modules.test.ts
+++ b/test/shared-modules.test.ts
@@ -12,6 +12,7 @@ import {
   DEFAULT_SUPABASE_OAUTH_PORT,
 } from "../src/shared/api.ts";
 import { readSupabaseConfig } from "../src/shared/cfg.ts";
+import { createSupabaseLogger } from "../src/shared/log.ts";
 import { buildAuthorizeUrl } from "../src/shared/oauth.ts";
 import type { FetchLike } from "../src/shared/types.ts";
 
@@ -69,15 +70,15 @@ describe("shared config", () => {
     });
   });
 
-  test("fails fast when client id is missing", () => {
-    expect(() =>
-      readSupabaseConfig(
-        {
-          oauthPort: 1456,
-        },
-        {},
-      ),
-    ).toThrow("Missing required Supabase config: clientId");
+  test("uses the default client id when not provided", () => {
+    const config = readSupabaseConfig(
+      {
+        oauthPort: 1456,
+      },
+      {},
+    );
+
+    expect(config.clientId).toBe(DEFAULT_SUPABASE_OAUTH_CLIENT_ID);
   });
 
   test("uses default broker base url when not provided", () => {
@@ -92,15 +93,15 @@ describe("shared config", () => {
     expect(config.brokerBaseUrl).toBe("https://iaoxncwzemnfxcdwakzb.supabase.co/functions/v1/opencode-supabase-broker");
   });
 
-  test("fails fast when oauth port is missing or invalid", () => {
-    expect(() =>
+  test("uses the default oauth port and rejects invalid env ports", () => {
+    expect(
       readSupabaseConfig(
         {
           clientId: "plugin-client",
         },
         {},
-      ),
-    ).toThrow("Missing required Supabase config: oauthPort");
+      ).oauthPort,
+    ).toBe(DEFAULT_SUPABASE_OAUTH_PORT);
 
     expect(() =>
       readSupabaseConfig(undefined, {
@@ -126,6 +127,32 @@ describe("shared oauth", () => {
     expect(url).toBe(
       "https://example.com/oauth/authorize?response_type=code&client_id=plugin-client&redirect_uri=http%3A%2F%2Flocalhost%3A1456%2Fcallback&code_challenge=challenge&code_challenge_method=S256&state=state-123",
     );
+  });
+});
+
+describe("shared log", () => {
+  test("writes structured entries with the supabase service name", async () => {
+    const write = mock(async () => true);
+    const logger = createSupabaseLogger({ write });
+
+    await logger.info("supabase auth started", { phase: "authorize" });
+
+    expect(write).toHaveBeenCalledTimes(1);
+    expect(write).toHaveBeenCalledWith({
+      service: "opencode-supabase",
+      level: "info",
+      message: "supabase auth started",
+      extra: { phase: "authorize" },
+    });
+  });
+
+  test("swallows host logger failures", async () => {
+    const write = mock(async () => {
+      throw new Error("host logger offline");
+    });
+    const logger = createSupabaseLogger({ write });
+
+    await expect(logger.error("supabase auth failed")).resolves.toBeUndefined();
   });
 });
 


### PR DESCRIPTION
## Summary
- add structured OpenCode logging for Supabase auth, broker, TUI, and tool execution
- redact sensitive values while keeping enough context to debug auth and broker failures
- add a small README debug logging section with the capture command and default log paths

## Test Plan
- [x] bun test
- [x] bun run typecheck