### PR TITLE
ci: add bun gates and plugin smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           export XDG_DATA_HOME="$HOME/.local/share"
           export XDG_CACHE_HOME="$HOME/.cache"
 
-          TARBALL="$(npm pack | tail -n 1)"
+          TARBALL="$(npm pack --json | jq -r '.[0].filename')"
           SPEC="opencode-supabase@file:$(pwd)/$TARBALL"
 
           WORKDIR="$(mktemp -d)"
@@ -65,4 +65,7 @@ jobs:
           git init -q
 
           opencode plugin "$SPEC"
-          opencode debug config | jq -e --arg spec "$SPEC" '.plugin_origins | any(.spec == $spec and .scope == "local")'
+          CONFIG_JSON="$(opencode debug config)"
+          printf 'Smoke spec: %s\n' "$SPEC"
+          printf '%s\n' "$CONFIG_JSON" | jq '{plugin, plugin_origins}'
+          printf '%s\n' "$CONFIG_JSON" | jq -e --arg spec "$SPEC" '.plugin_origins | any(.spec == $spec and .scope == "local")'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,68 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  core:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Lint
+        run: bun run lint
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Test
+        run: bun test
+
+      - name: Verify package
+        run: bun run verify:pack
+
+  plugin-smoke:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.11
+
+      - name: Install OpenCode
+        run: npm i -g opencode-ai@1.4.3
+
+      - name: Smoke plugin install
+        run: |
+          set -euo pipefail
+          export HOME="$(mktemp -d)"
+          export XDG_CONFIG_HOME="$HOME/.config"
+          export XDG_DATA_HOME="$HOME/.local/share"
+          export XDG_CACHE_HOME="$HOME/.cache"
+
+          TARBALL="$(npm pack | tail -n 1)"
+          SPEC="opencode-supabase@file:$(pwd)/$TARBALL"
+
+          WORKDIR="$(mktemp -d)"
+          cd "$WORKDIR"
+          git init -q
+
+          opencode plugin "$SPEC"
+          opencode debug config | jq -e --arg spec "$SPEC" '.plugin_origins | any(.spec == $spec and .scope == "local")'

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "formatter": {
+    "enabled": false
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  }
+}

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "zod": "latest",
       },
       "devDependencies": {
+        "@biomejs/biome": "^1.9.4",
         "@opentui/core": "0.1.95",
         "@opentui/solid": "0.1.95",
         "@types/bun": "latest",
@@ -78,6 +79,24 @@
     "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@biomejs/biome": ["@biomejs/biome@1.9.4", "", { "optionalDependencies": { "@biomejs/cli-darwin-arm64": "1.9.4", "@biomejs/cli-darwin-x64": "1.9.4", "@biomejs/cli-linux-arm64": "1.9.4", "@biomejs/cli-linux-arm64-musl": "1.9.4", "@biomejs/cli-linux-x64": "1.9.4", "@biomejs/cli-linux-x64-musl": "1.9.4", "@biomejs/cli-win32-arm64": "1.9.4", "@biomejs/cli-win32-x64": "1.9.4" }, "bin": { "biome": "bin/biome" } }, "sha512-1rkd7G70+o9KkTn5KLmDYXihGoTaIGO9PIIN2ZB7UJxFrWw04CZHPYiMRjYsaDvVV7hP1dYNRLxSANLaBFGpog=="],
+
+    "@biomejs/cli-darwin-arm64": ["@biomejs/cli-darwin-arm64@1.9.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw=="],
+
+    "@biomejs/cli-darwin-x64": ["@biomejs/cli-darwin-x64@1.9.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-ngYBh/+bEedqkSevPVhLP4QfVPCpb+4BBe2p7Xs32dBgs7rh9nY2AIYUL6BgLw1JVXV8GlpKmb/hNiuIxfPfZg=="],
+
+    "@biomejs/cli-linux-arm64": ["@biomejs/cli-linux-arm64@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-fJIW0+LYujdjUgJJuwesP4EjIBl/N/TcOX3IvIHJQNsAqvV2CHIogsmA94BPG6jZATS4Hi+xv4SkBBQSt1N4/g=="],
+
+    "@biomejs/cli-linux-arm64-musl": ["@biomejs/cli-linux-arm64-musl@1.9.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA=="],
+
+    "@biomejs/cli-linux-x64": ["@biomejs/cli-linux-x64@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-lRCJv/Vi3Vlwmbd6K+oQ0KhLHMAysN8lXoCI7XeHlxaajk06u7G+UsFSO01NAs5iYuWKmVZjmiOzJ0OJmGsMwg=="],
+
+    "@biomejs/cli-linux-x64-musl": ["@biomejs/cli-linux-x64-musl@1.9.4", "", { "os": "linux", "cpu": "x64" }, "sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg=="],
+
+    "@biomejs/cli-win32-arm64": ["@biomejs/cli-win32-arm64@1.9.4", "", { "os": "win32", "cpu": "arm64" }, "sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg=="],
+
+    "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@1.9.4", "", { "os": "win32", "cpu": "x64" }, "sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA=="],
 
     "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
 

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "tui"
   ],
   "scripts": {
+    "lint": "biome check .",
+    "verify:pack": "npm pack --dry-run",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test"
   },
@@ -33,6 +35,7 @@
     "zod": "latest"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@opentui/core": "0.1.95",
     "@opentui/solid": "0.1.95",
     "@types/bun": "latest",

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -1,10 +1,10 @@
-import type { PluginInput, PluginOptions } from "@opencode-ai/plugin";
 import { createConnection } from "node:net";
+import type { PluginInput, PluginOptions } from "@opencode-ai/plugin";
 
 import {
   BrokerClientError,
-  exchangeCodeThroughBroker,
   type BrokerConfig,
+  exchangeCodeThroughBroker,
 } from "../shared/broker.ts";
 import { readSupabaseConfig } from "../shared/cfg.ts";
 import type { SupabaseLogger } from "../shared/log.ts";

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -1,6 +1,6 @@
-import type { PluginInput } from "@opencode-ai/plugin";
 import { mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
+import type { PluginInput } from "@opencode-ai/plugin";
 
 type StoreInput = Pick<PluginInput, "directory" | "worktree">;
 

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -1,16 +1,16 @@
 import type { PluginOptions } from "@opencode-ai/plugin";
-import type { ToolContext } from "@opencode-ai/plugin/tool";
 import { tool } from "@opencode-ai/plugin";
+import type { ToolContext } from "@opencode-ai/plugin/tool";
 
+import { supabaseManagementApiFetch } from "../shared/api.ts";
 import {
   BrokerClientError,
   refreshTokenThroughBroker,
 } from "../shared/broker.ts";
-import { supabaseManagementApiFetch } from "../shared/api.ts";
 import { readSupabaseConfig } from "../shared/cfg.ts";
 import type { SupabaseLogger } from "../shared/log.ts";
 import type { FetchLike } from "../shared/types.ts";
-import { clearSavedAuth, readSavedAuth, writeSavedAuth, type SavedAuth } from "./store.ts";
+import { type SavedAuth, clearSavedAuth, readSavedAuth, writeSavedAuth } from "./store.ts";
 
 type ToolDeps = {
   fetch?: FetchLike;

--- a/src/shared/broker.ts
+++ b/src/shared/broker.ts
@@ -1,5 +1,5 @@
-import type { FetchLike, SupabaseTokenResponse } from "./types.ts";
 import type { SupabaseLogger } from "./log.ts";
+import type { FetchLike, SupabaseTokenResponse } from "./types.ts";
 
 export type BrokerConfig = {
   baseUrl: string;

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "bun:test";
 
+import serverModule from "../src/server/index.ts";
 import { createSupabaseCommand } from "../src/tui/commands.ts";
 import { SupabaseDialog } from "../src/tui/dialog.tsx";
-import serverModule from "../src/server/index.ts";
 import tuiModule from "../src/tui/index.tsx";
 
 test("server plugin exports supabase id and server hook", () => {
@@ -124,7 +124,7 @@ test("supabase dialog treats boolean callback success as connected", async () =>
         },
       },
     },
-  } as any;
+  } as unknown as Parameters<typeof SupabaseDialog>[0]["api"];
 
   const logger = {
     debug: () => Promise.resolve(),
@@ -175,17 +175,21 @@ test("supabase dialog logs auth milestones without leaking oauth query values", 
         },
       },
     },
-  } as any;
+  } as unknown as Parameters<typeof SupabaseDialog>[0]["api"];
 
   const logger = {
-    debug: (message: string, extra?: Record<string, unknown>) =>
-      api.client.app.log({ service: "opencode-supabase", level: "debug", message, extra }),
-    info: (message: string, extra?: Record<string, unknown>) =>
-      api.client.app.log({ service: "opencode-supabase", level: "info", message, extra }),
-    warn: (message: string, extra?: Record<string, unknown>) =>
-      api.client.app.log({ service: "opencode-supabase", level: "warn", message, extra }),
-    error: (message: string, extra?: Record<string, unknown>) =>
-      api.client.app.log({ service: "opencode-supabase", level: "error", message, extra }),
+    debug: async (message: string, extra?: Record<string, unknown>) => {
+      await api.client.app.log({ service: "opencode-supabase", level: "debug", message, extra });
+    },
+    info: async (message: string, extra?: Record<string, unknown>) => {
+      await api.client.app.log({ service: "opencode-supabase", level: "info", message, extra });
+    },
+    warn: async (message: string, extra?: Record<string, unknown>) => {
+      await api.client.app.log({ service: "opencode-supabase", level: "warn", message, extra });
+    },
+    error: async (message: string, extra?: Record<string, unknown>) => {
+      await api.client.app.log({ service: "opencode-supabase", level: "error", message, extra });
+    },
   };
 
   const dialog = SupabaseDialog({ api, logger, onClose: () => api.ui.dialog.clear() }) as {

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { createSupabaseAuth, stopSupabaseAuthServer } from "../src/server/auth.ts";
 import { readSavedAuth } from "../src/server/store.ts";
@@ -20,11 +20,23 @@ async function createInput() {
   };
 }
 
+function firstAuthMethod(auth: ReturnType<typeof createSupabaseAuth>) {
+  const method = auth.methods[0];
+  if (!method) throw new Error("Expected an auth method");
+  return method;
+}
+
+function requireSearchParam(url: URL, key: string) {
+  const value = url.searchParams.get(key);
+  if (!value) throw new Error(`Missing ${key}`);
+  return value;
+}
+
 afterEach(async () => {
   await stopSupabaseAuthServer();
   await Promise.all(cleanupPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
   if (originalBrokerUrl === undefined) {
-    delete process.env.OPENCODE_SUPABASE_BROKER_URL;
+    process.env.OPENCODE_SUPABASE_BROKER_URL = undefined;
   } else {
     process.env.OPENCODE_SUPABASE_BROKER_URL = originalBrokerUrl;
   }
@@ -56,10 +68,10 @@ describe("server auth hook", () => {
       },
     );
 
-    const result = await auth.methods[0]!.authorize();
+    const result = await firstAuthMethod(auth).authorize();
     const authUrl = new URL(result.url);
-    const redirectUri = new URL(authUrl.searchParams.get("redirect_uri")!);
-    const state = authUrl.searchParams.get("state");
+    const redirectUri = new URL(requireSearchParam(authUrl, "redirect_uri"));
+    const state = requireSearchParam(authUrl, "state");
 
     const pending = result.callback();
     await fetch(`${redirectUri.toString()}?code=code-123&state=${state}`);
@@ -102,10 +114,10 @@ describe("server auth hook", () => {
       },
     );
 
-    const result = await auth.methods[0]!.authorize();
+    const result = await firstAuthMethod(auth).authorize();
     const authUrl = new URL(result.url);
-    const redirectUri = new URL(authUrl.searchParams.get("redirect_uri")!);
-    const state = authUrl.searchParams.get("state");
+    const redirectUri = new URL(requireSearchParam(authUrl, "redirect_uri"));
+    const state = requireSearchParam(authUrl, "state");
 
     const pending = result.callback();
     pending.catch(() => undefined);
@@ -133,10 +145,10 @@ describe("server auth hook", () => {
       },
     );
 
-    const result = await auth.methods[0]!.authorize();
+    const result = await firstAuthMethod(auth).authorize();
     const authUrl = new URL(result.url);
-    const redirectUri = new URL(authUrl.searchParams.get("redirect_uri")!);
-    const state = authUrl.searchParams.get("state");
+    const redirectUri = new URL(requireSearchParam(authUrl, "redirect_uri"));
+    const state = requireSearchParam(authUrl, "state");
 
     const pending = result.callback();
     pending.catch(() => undefined);
@@ -169,7 +181,7 @@ describe("server auth hook", () => {
       },
     );
 
-    const result = await auth.methods[0]!.authorize();
+    const result = await firstAuthMethod(auth).authorize();
     await expect(result.callback()).rejects.toThrow("OAuth callback timeout - authorization took too long");
 
     const logEntries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
@@ -199,7 +211,7 @@ describe("server auth hook", () => {
       },
     );
 
-    const result = await auth.methods[0]?.authorize();
+    const result = await firstAuthMethod(auth).authorize();
     void result?.callback().catch(() => undefined);
 
     expect(result?.method).toBe("auto");
@@ -236,9 +248,9 @@ describe("server auth hook", () => {
       },
     );
 
-    const result = await auth.methods[0]?.authorize();
+    const result = await firstAuthMethod(auth).authorize();
     void result?.callback().catch(() => undefined);
-    const redirectUri = new URL(new URL(String(result?.url)).searchParams.get("redirect_uri")!);
+    const redirectUri = new URL(requireSearchParam(new URL(String(result.url)), "redirect_uri"));
 
     const response = await fetch(`${redirectUri.toString()}?code=code-123`);
     const html = await response.text();
@@ -287,10 +299,10 @@ describe("server auth hook", () => {
       { fetch: fetchMock as unknown as FetchLike },
     );
 
-    const result = await auth.methods[0]!.authorize();
+    const result = await firstAuthMethod(auth).authorize();
     const authUrl = new URL(result.url);
-    const redirectUri = new URL(authUrl.searchParams.get("redirect_uri")!);
-    const state = authUrl.searchParams.get("state");
+    const redirectUri = new URL(requireSearchParam(authUrl, "redirect_uri"));
+    const state = requireSearchParam(authUrl, "state");
 
     const pending = result.callback();
     const response = await fetch(`${redirectUri.toString()}?code=code-123&state=${state}`);

--- a/test/server-store.test.ts
+++ b/test/server-store.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
 
 import { clearSavedAuth, getStoreFile, readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
 

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -1,15 +1,15 @@
-import type { ToolContext } from "@opencode-ai/plugin/tool";
 import { afterEach, describe, expect, mock, test } from "bun:test";
 import { mkdtemp, rm } from "node:fs/promises";
-import { join } from "node:path";
 import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { ToolContext } from "@opencode-ai/plugin/tool";
 
+import { readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
 import {
+  type SupabaseToolInput,
   createSupabaseTools,
   ensureSupabaseToolAuth,
-  type SupabaseToolInput,
 } from "../src/server/tools.ts";
-import { readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
 import { createSupabaseLogger } from "../src/shared/log.ts";
 import type { FetchLike } from "../src/shared/types.ts";
 
@@ -64,7 +64,7 @@ function createContext(input: TestPluginInput): TestToolContext {
 afterEach(async () => {
   await Promise.all(cleanupPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
   if (originalBrokerUrl === undefined) {
-    delete process.env.OPENCODE_SUPABASE_BROKER_URL;
+    process.env.OPENCODE_SUPABASE_BROKER_URL = undefined;
   } else {
     process.env.OPENCODE_SUPABASE_BROKER_URL = originalBrokerUrl;
   }
@@ -255,7 +255,7 @@ describe("server tools auth helper", () => {
         );
       }
 
-      if (url === "http://127.0.0.1:7777/auth/supabase?directory=" + encodeURIComponent(input.directory)) {
+      if (url === `http://127.0.0.1:7777/auth/supabase?directory=${encodeURIComponent(input.directory)}`) {
         return new Response(JSON.stringify(true), {
           status: 200,
           headers: { "Content-Type": "application/json" },
@@ -508,7 +508,7 @@ describe("server tools auth helper", () => {
         );
       }
 
-      if (url === "http://127.0.0.1:7777/auth/supabase?directory=" + encodeURIComponent(input.directory)) {
+      if (url === `http://127.0.0.1:7777/auth/supabase?directory=${encodeURIComponent(input.directory)}`) {
         throw new Error("delete failed");
       }
 

--- a/test/shared-modules.test.ts
+++ b/test/shared-modules.test.ts
@@ -1,22 +1,22 @@
 import { describe, expect, mock, test } from "bun:test";
 
 import {
-  BrokerClientError,
-  exchangeCodeThroughBroker,
-  refreshTokenThroughBroker,
-} from "../src/shared/broker.ts";
-import {
   DEFAULT_SUPABASE_API_BASE_URL,
   DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL,
   DEFAULT_SUPABASE_OAUTH_CLIENT_ID,
   DEFAULT_SUPABASE_OAUTH_PORT,
 } from "../src/shared/api.ts";
+import {
+  BrokerClientError,
+  exchangeCodeThroughBroker,
+  refreshTokenThroughBroker,
+} from "../src/shared/broker.ts";
 import { readSupabaseConfig } from "../src/shared/cfg.ts";
 import {
-  createSupabaseLogger,
-  createServerLogWriter,
-  createTuiLogWriter,
   type LogEntry,
+  createServerLogWriter,
+  createSupabaseLogger,
+  createTuiLogWriter,
 } from "../src/shared/log.ts";
 import { buildAuthorizeUrl } from "../src/shared/oauth.ts";
 import type { FetchLike } from "../src/shared/types.ts";
@@ -201,7 +201,7 @@ describe("server log writer", () => {
     await write(entry);
 
     expect(logCalls).toHaveLength(1);
-    expect(logCalls[0]!.body).toEqual(entry);
+    expect(logCalls[0]?.body).toEqual(entry);
   });
 });
 
@@ -222,8 +222,8 @@ describe("tui log writer", () => {
     await write(entry);
 
     expect(logCalls).toHaveLength(1);
-    expect(logCalls[0]!.params).toEqual(entry);
-    expect(logCalls[0]!.options.throwOnError).toBe(true);
+    expect(logCalls[0]?.params).toEqual(entry);
+    expect(logCalls[0]?.options.throwOnError).toBe(true);
   });
 });
 

--- a/test/supabase-broker.test.ts
+++ b/test/supabase-broker.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, mock, test } from "bun:test";
 
-import { buildConfigFromEnv, brokerHandler, handleBrokerRequest } from "../supabase/functions/opencode-supabase-broker/index.ts";
 import { handleExchangeRequest, handleRefreshRequest } from "../supabase/functions/opencode-supabase-broker/handlers.ts";
+import { brokerHandler, buildConfigFromEnv, handleBrokerRequest } from "../supabase/functions/opencode-supabase-broker/index.ts";
 import { BrokerConfigError } from "../supabase/functions/opencode-supabase-broker/types.ts";
 import type { BrokerConfig, TokenResponse } from "../supabase/functions/opencode-supabase-broker/types.ts";
 


### PR DESCRIPTION
## Summary
- Add Biome, `lint`, and `verify:pack` so CI gates use Bun-native checks.
- Add a separate optional plugin smoke job that installs from a local npm tarball and verifies plugin registration.
- Apply the Biome import and lint fixes needed to keep the repo green.

## Test Plan
- [x] `bun run lint`
- [x] `bun run typecheck`
- [x] `bun test`
- [x] `bun run verify:pack`
- [x] Local smoke run with `npm pack`, `opencode plugin`, and `opencode debug config | jq ...`