### PR TITLE
fix auth callback port collisions

### DIFF
--- a/.changeset/fair-hotels-check.md
+++ b/.changeset/fair-hotels-check.md
@@ -1,0 +1,5 @@
+---
+'opencode-supabase': patch
+---
+
+Fix Supabase OAuth callback collisions by retrying a fixed localhost callback window (`14589`-`14591`) and stopping the callback listener as soon as auth finishes.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ Launch `opencode` in your project, then run:
 
 Connect your account and ask your agent about Supabase capabilities.
 
+## OAuth Callback Contract
+
+Plugin uses fixed localhost callback window for browser auth:
+
+- `http://localhost:14589/auth/callback`
+- `http://localhost:14590/auth/callback`
+- `http://localhost:14591/auth/callback`
+
+Your Supabase OAuth app must allow all 3 redirect URIs.
+
+Maintainer note: deployed OAuth app config must stay in sync with this fixed callback set. If callback ports change in code later, update OAuth app setup too.
+
 ## Debug Logging
 
 If you hit auth or tool errors and need logs for an issue, collect the newest OpenCode session log from its default log directory:

--- a/TESTING.md
+++ b/TESTING.md
@@ -72,16 +72,19 @@ Export the required variables before launching OpenCode:
 ```bash
 export OPENCODE_SUPABASE_BROKER_URL=http://localhost:54321/functions/v1/opencode-supabase-broker
 export OPENCODE_SUPABASE_OAUTH_CLIENT_ID=<your_supabase_oauth_app_client_id>
-export OPENCODE_SUPABASE_OAUTH_PORT=14589
 ```
 
-The callback URL is:
+Plugin uses fixed callback window:
 
 ```text
 http://localhost:14589/auth/callback
+http://localhost:14590/auth/callback
+http://localhost:14591/auth/callback
 ```
 
-Your Supabase OAuth app must allow that redirect URI.
+Your Supabase OAuth app must allow all 3 redirect URIs above.
+
+Important: update both local/dev OAuth app config and deployed OAuth app config before testing fallback behavior.
 
 Then launch OpenCode and run:
 
@@ -131,12 +134,6 @@ Missing plugin client ID:
 export OPENCODE_SUPABASE_OAUTH_CLIENT_ID=<your_supabase_oauth_app_client_id>
 ```
 
-Missing plugin callback port:
-
-```bash
-export OPENCODE_SUPABASE_OAUTH_PORT=14589
-```
-
 Broker returns a generic `500`:
 
 - verify `supabase/functions/.env` contains valid values for `OPENCODE_SUPABASE_OAUTH_CLIENT_ID` and `OPENCODE_SUPABASE_OAUTH_CLIENT_SECRET`
@@ -144,3 +141,8 @@ Broker returns a generic `500`:
 Redirect rejected:
 
 - verify the OAuth app redirect URI, plugin callback URI, and broker allowlist all match
+
+All callback ports busy:
+
+- plugin retries `14589`, `14590`, then `14591`
+- if all 3 are busy, close other OpenCode sessions or stale local processes and retry

--- a/docs/supabase-oauth-broker-contract.md
+++ b/docs/supabase-oauth-broker-contract.md
@@ -66,7 +66,10 @@ Supabase remains:
 ### Initial login
 
 1. The plugin generates `state`, PKCE `code_verifier`, and `code_challenge`.
-2. The plugin starts a local callback listener such as `http://localhost:<port>/auth/callback`.
+2. The plugin starts a local callback listener using one fixed callback URL from its localhost window:
+   - `http://localhost:14589/auth/callback`
+   - `http://localhost:14590/auth/callback`
+   - `http://localhost:14591/auth/callback`
 3. The plugin opens the browser to `https://api.supabase.com/v1/oauth/authorize` with:
    - `client_id`
    - `redirect_uri`
@@ -219,10 +222,13 @@ The broker should never return raw HTML or opaque passthrough responses to the p
 
 ## Suggested redirect URI policy
 
-The broker should accept only local plugin callback URLs. Recommended patterns:
+The broker should accept only plugin-owned localhost callback URLs. Current plugin contract:
 
-- `http://localhost:<port>/auth/callback`
-- optionally `http://localhost:<port>/auth/callback` if the plugin intentionally supports it
+- `http://localhost:14589/auth/callback`
+- `http://localhost:14590/auth/callback`
+- `http://localhost:14591/auth/callback`
+
+Operational note: Supabase OAuth app setup must register all callback URLs in this fixed set. If plugin callback ports change later, deployed OAuth app configuration must change too.
 
 The broker should reject:
 

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -15,6 +15,7 @@ import { writeSavedAuth } from "./store.ts";
 
 const CALLBACK_PATH = "/auth/callback";
 const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
+const CALLBACK_PORTS = [14589, 14590, 14591] as const;
 
 type PendingAuth = {
   codeVerifier: string;
@@ -25,6 +26,7 @@ type PendingAuth = {
 };
 
 type AuthDeps = {
+  callbackPorts?: number[];
   fetch?: FetchLike;
   logger?: SupabaseLogger;
   setCallbackTimeout?: typeof setTimeout;
@@ -36,6 +38,13 @@ const pendingAuths = new Map<string, PendingAuth>();
 
 function callbackUrl(port: number) {
   return `http://localhost:${port}${CALLBACK_PATH}`;
+}
+
+function normalizeCallbackPorts(ports: readonly number[]) {
+  if (ports.length === 0) {
+    throw new Error("Supabase callback ports must not be empty");
+  }
+  return [...ports];
 }
 
 async function isPortInUse(port: number) {
@@ -52,139 +61,183 @@ async function isPortInUse(port: number) {
 }
 
 async function ensureServer(
-  port: number,
-  config: ReturnType<typeof readSupabaseConfig>,
+  callbackPorts: readonly number[],
+  _config: ReturnType<typeof readSupabaseConfig>,
   input: Pick<PluginInput, "directory" | "worktree">,
   deps: AuthDeps,
 ) {
+  const candidatePorts = normalizeCallbackPorts(callbackPorts);
+
   if (server) {
-    if (serverPort !== port) {
+    if (!serverPort || !candidatePorts.includes(serverPort)) {
       throw new Error(`Supabase callback server already running on port ${serverPort}`);
     }
-    return;
-  }
-
-  if (await isPortInUse(port)) {
-    throw new Error(`Supabase callback port ${port} is already in use`);
+    return serverPort;
   }
 
   const brokerConfig: BrokerConfig = {
-    baseUrl: config.brokerBaseUrl,
+    baseUrl: _config.brokerBaseUrl,
   };
 
-  await deps.logger?.info("supabase callback server started", {
-    port,
-  });
-
-  server = Bun.serve({
-    port,
-    async fetch(req) {
-      const url = new URL(req.url);
-      if (url.pathname !== CALLBACK_PATH) {
-        return new Response("Not found", { status: 404 });
-      }
-
-      const state = url.searchParams.get("state");
-      await deps.logger?.debug("supabase auth callback received", {
-        has_state: Boolean(state),
-        has_code: Boolean(url.searchParams.get("code")),
-        has_error: Boolean(url.searchParams.get("error")),
-      });
-      if (!state) {
-        return new Response(htmlError("Missing required state parameter - potential CSRF attack"), {
-          status: 400,
-          headers: { "Content-Type": "text/html" },
-        });
-      }
-
-      const pending = pendingAuths.get(state);
-      if (!pending) {
-        return new Response(htmlError("Invalid or expired state parameter - potential CSRF attack"), {
-          status: 400,
-          headers: { "Content-Type": "text/html" },
-        });
-      }
-
-      const error = url.searchParams.get("error");
-      const errorDescription = url.searchParams.get("error_description");
-      if (error) {
-        clearTimeout(pending.timeout);
-        pendingAuths.delete(state);
-        await deps.logger?.error("supabase auth failed", {
-          reason: "provider_denied",
-        });
-        pending.reject(new Error(errorDescription || error));
-        return new Response(htmlError(errorDescription || error), {
-          headers: { "Content-Type": "text/html" },
-        });
-      }
-
-      const code = url.searchParams.get("code");
-      if (!code) {
-        clearTimeout(pending.timeout);
-        pendingAuths.delete(state);
-        await deps.logger?.error("supabase auth failed", {
-          reason: "missing_code",
-        });
-        pending.reject(new Error("Missing authorization code"));
-        return new Response(htmlError("Missing authorization code"), {
-          status: 400,
-          headers: { "Content-Type": "text/html" },
-        });
-      }
-
-      clearTimeout(pending.timeout);
-      pendingAuths.delete(state);
-
+  let selectedPort: number | undefined;
+  for (const port of candidatePorts) {
+    const portBusy = await isPortInUse(port);
+    await deps.logger?.debug("supabase callback port probe", {
+      port,
+      available: !portBusy,
+    });
+    if (!portBusy) {
       try {
-        const tokens = await exchangeCodeThroughBroker(
-          brokerConfig,
-          {
-            code,
-            redirect_uri: pending.redirectUri,
-            code_verifier: pending.codeVerifier,
+        server = Bun.serve({
+          port,
+          async fetch(req) {
+            const url = new URL(req.url);
+            if (url.pathname !== CALLBACK_PATH) {
+              return new Response("Not found", { status: 404 });
+            }
+
+            const state = url.searchParams.get("state");
+            await deps.logger?.debug("supabase auth callback received", {
+              has_state: Boolean(state),
+              has_code: Boolean(url.searchParams.get("code")),
+              has_error: Boolean(url.searchParams.get("error")),
+            });
+            if (!state) {
+              return new Response(htmlError("Missing required state parameter - potential CSRF attack"), {
+                status: 400,
+                headers: { "Content-Type": "text/html" },
+              });
+            }
+
+            const pending = pendingAuths.get(state);
+            if (!pending) {
+              return new Response(htmlError("Invalid or expired state parameter - potential CSRF attack"), {
+                status: 400,
+                headers: { "Content-Type": "text/html" },
+              });
+            }
+
+            const error = url.searchParams.get("error");
+            const errorDescription = url.searchParams.get("error_description");
+            if (error) {
+              clearTimeout(pending.timeout);
+              pendingAuths.delete(state);
+              await deps.logger?.error("supabase auth failed", {
+                reason: "provider_denied",
+              });
+              pending.reject(new Error(errorDescription || error));
+              await stopServerIfIdle(deps.logger, "provider_denied");
+              return new Response(htmlError(errorDescription || error), {
+                headers: { "Content-Type": "text/html" },
+              });
+            }
+
+            const code = url.searchParams.get("code");
+            if (!code) {
+              clearTimeout(pending.timeout);
+              pendingAuths.delete(state);
+              await deps.logger?.error("supabase auth failed", {
+                reason: "missing_code",
+              });
+              pending.reject(new Error("Missing authorization code"));
+              await stopServerIfIdle(deps.logger, "missing_code");
+              return new Response(htmlError("Missing authorization code"), {
+                status: 400,
+                headers: { "Content-Type": "text/html" },
+              });
+            }
+
+            clearTimeout(pending.timeout);
+            pendingAuths.delete(state);
+
+            try {
+              const tokens = await exchangeCodeThroughBroker(
+                brokerConfig,
+                {
+                  code,
+                  redirect_uri: pending.redirectUri,
+                  code_verifier: pending.codeVerifier,
+                },
+                deps.fetch,
+                deps.logger,
+              );
+
+              const expires = Date.now() + (tokens.expires_in || 3600) * 1000;
+              await writeSavedAuth(input, {
+                access: tokens.access_token,
+                refresh: tokens.refresh_token,
+                expires,
+              });
+
+              pending.resolve({ tokens, expires });
+
+              await deps.logger?.info("supabase auth completed", {
+                status: "success",
+              });
+
+              await stopServerIfIdle(deps.logger, "auth_completed");
+
+              return new Response(HTML_SUCCESS, {
+                headers: { "Content-Type": "text/html" },
+              });
+            } catch (cause) {
+              const errorMessage = cause instanceof BrokerClientError
+                ? `Authorization failed: ${cause.message}`
+                : "Authorization failed";
+
+              await deps.logger?.error("supabase auth failed", {
+                status: cause instanceof BrokerClientError ? cause.status : 400,
+                broker_error: cause instanceof BrokerClientError,
+              });
+
+              pending.reject(cause instanceof Error ? cause : new Error(String(cause)));
+              await stopServerIfIdle(deps.logger, "broker_exchange_failed");
+
+              return new Response(htmlError(errorMessage), {
+                status: cause instanceof BrokerClientError && cause.status >= 500 ? 502 : 400,
+                headers: { "Content-Type": "text/html" },
+              });
+            }
           },
-          deps.fetch,
-          deps.logger,
-        );
-
-        const expires = Date.now() + (tokens.expires_in || 3600) * 1000;
-        await writeSavedAuth(input, {
-          access: tokens.access_token,
-          refresh: tokens.refresh_token,
-          expires,
         });
-
-        pending.resolve({ tokens, expires });
-
-        await deps.logger?.info("supabase auth completed", {
-          status: "success",
-        });
-
-        return new Response(HTML_SUCCESS, {
-          headers: { "Content-Type": "text/html" },
-        });
-      } catch (cause) {
-        const errorMessage = cause instanceof BrokerClientError
-          ? `Authorization failed: ${cause.message}`
-          : "Authorization failed";
-
-        await deps.logger?.error("supabase auth failed", {
-          status: cause instanceof BrokerClientError ? cause.status : 400,
-          broker_error: cause instanceof BrokerClientError,
-        });
-
-        pending.reject(cause instanceof Error ? cause : new Error(String(cause)));
-
-        return new Response(htmlError(errorMessage), {
-          status: cause instanceof BrokerClientError && cause.status >= 500 ? 502 : 400,
-          headers: { "Content-Type": "text/html" },
+        selectedPort = port;
+        break;
+      } catch (error) {
+        await deps.logger?.warn("supabase callback server bind failed", {
+          port,
+          message: error instanceof Error ? error.message : String(error),
         });
       }
-    },
+    }
+  }
+
+  if (selectedPort === undefined) {
+    await deps.logger?.error("supabase callback port window exhausted", {
+      ports_tried: candidatePorts,
+    });
+    throw new Error(
+      `Supabase callback ports busy: ${candidatePorts.join(", ")}. Close other OpenCode sessions and retry.`,
+    );
+  }
+
+  await deps.logger?.info("supabase callback server started", {
+    port: selectedPort,
   });
 
-  serverPort = port;
+  serverPort = selectedPort;
+  return selectedPort;
+}
+
+async function stopServerIfIdle(logger?: SupabaseLogger, reason?: string) {
+  if (pendingAuths.size > 0 || !server) return;
+  const port = serverPort;
+  server.stop();
+  server = undefined;
+  serverPort = undefined;
+  await logger?.info("supabase callback server stopped", {
+    reason,
+    port,
+  });
 }
 
 function waitForCallback(
@@ -201,6 +254,7 @@ function waitForCallback(
       void deps.logger?.error("supabase auth callback timed out", {
         reason: "timeout",
       });
+      void stopServerIfIdle(deps.logger, "timeout");
       reject(new Error("OAuth callback timeout - authorization took too long"));
     }, CALLBACK_TIMEOUT_MS);
 
@@ -220,6 +274,7 @@ export function createSupabaseAuth(
   deps: AuthDeps = {},
 ) {
   const config = readSupabaseConfig(options);
+  const authCallbackPorts = normalizeCallbackPorts(deps.callbackPorts ?? CALLBACK_PORTS);
 
   return {
     provider: "supabase",
@@ -228,13 +283,13 @@ export function createSupabaseAuth(
         type: "oauth" as const,
         label: "Supabase",
         async authorize() {
-          await ensureServer(config.oauthPort, config, input, deps);
+          const port = await ensureServer(authCallbackPorts, config, input, deps);
           await deps.logger?.info("supabase auth started", {
-            port: config.oauthPort,
+            port,
           });
           const pkce = await generatePKCE();
           const state = generateState();
-          const redirectUri = callbackUrl(config.oauthPort);
+          const redirectUri = callbackUrl(port);
           const callbackPromise = waitForCallback(state, pkce.verifier, redirectUri, deps);
 
           return {

--- a/src/shared/cfg.ts
+++ b/src/shared/cfg.ts
@@ -18,26 +18,6 @@ function readEnvString(value: string | undefined): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
 }
 
-function readPortOption(options: PluginOptions | undefined, key: string) {
-  const value = options?.[key];
-  if (typeof value === "number") return value;
-  if (typeof value === "string" && value.trim()) return value.trim();
-  return undefined;
-}
-
-function requirePort(value: number | string | undefined) {
-  if (value === undefined) {
-    throw new Error("Missing required Supabase config: oauthPort");
-  }
-
-  const parsed = typeof value === "number" ? value : Number.parseInt(value, 10);
-  if (!Number.isInteger(parsed) || parsed <= 0) {
-    throw new Error("Invalid Supabase config: oauthPort must be a positive integer");
-  }
-
-  return parsed;
-}
-
 export function readSupabaseConfig(
   options: PluginOptions | undefined,
   env: SupabaseEnv = process.env,
@@ -46,11 +26,6 @@ export function readSupabaseConfig(
     readStringOption(options, "clientId") ??
     readEnvString(env.OPENCODE_SUPABASE_OAUTH_CLIENT_ID) ??
     DEFAULT_SUPABASE_OAUTH_CLIENT_ID;
-  const oauthPort = requirePort(
-    readPortOption(options, "oauthPort") ??
-    env.OPENCODE_SUPABASE_OAUTH_PORT ??
-    DEFAULT_SUPABASE_OAUTH_PORT,
-  );
   const brokerBaseUrl =
     readStringOption(options, "brokerBaseUrl") ??
     readEnvString(env.OPENCODE_SUPABASE_BROKER_URL) ??
@@ -58,7 +33,7 @@ export function readSupabaseConfig(
 
   return {
     clientId,
-    oauthPort,
+    oauthPort: DEFAULT_SUPABASE_OAUTH_PORT,
     authorizeUrl:
       readStringOption(options, "authorizeUrl") ??
       env.SUPABASE_OAUTH_AUTHORIZE_URL ??

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -204,3 +204,60 @@ test("supabase dialog logs auth milestones without leaking oauth query values", 
   expect(serialized).not.toContain("code=secret");
   expect(cleared).toBe(1);
 });
+
+test("supabase dialog shows explicit callback port exhaustion toast", async () => {
+  const toasts: Array<{ variant?: string; message: string }> = [];
+  let cleared = 0;
+
+  const api = {
+    ui: {
+      DialogAlert: (input: unknown) => input,
+      DialogConfirm: (input: unknown) => input,
+      toast: (input: { variant?: string; message: string }) => {
+        toasts.push(input);
+      },
+      dialog: {
+        clear: () => {
+          cleared += 1;
+        },
+      },
+    },
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      provider: {
+        oauth: {
+          authorize: () => Promise.resolve({
+            error: {
+              message: "Supabase callback ports busy: 14589, 14590, 14591. Close other OpenCode sessions and retry.",
+            },
+          }),
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  } as unknown as Parameters<typeof SupabaseDialog>[0]["api"];
+
+  const logger = {
+    debug: () => Promise.resolve(),
+    info: () => Promise.resolve(),
+    warn: () => Promise.resolve(),
+    error: () => Promise.resolve(),
+  };
+
+  const dialog = SupabaseDialog({ api, logger, onClose: () => api.ui.dialog.clear() }) as {
+    onConfirm?: () => Promise<void>;
+  };
+
+  await dialog.onConfirm?.();
+
+  expect(toasts).toEqual([
+    {
+      variant: "error",
+      message:
+        "Supabase authorization failed: Supabase callback ports busy: 14589, 14590, 14591. Close other OpenCode sessions and retry.",
+    },
+  ]);
+  expect(cleared).toBe(1);
+});

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -9,6 +9,7 @@ import { createSupabaseLogger } from "../src/shared/log.ts";
 import type { FetchLike } from "../src/shared/types.ts";
 
 const cleanupPaths: string[] = [];
+const occupiedPorts: Array<ReturnType<typeof Bun.serve>> = [];
 const originalBrokerUrl = process.env.OPENCODE_SUPABASE_BROKER_URL;
 
 async function createInput() {
@@ -32,8 +33,22 @@ function requireSearchParam(url: URL, key: string) {
   return value;
 }
 
+function occupyPort(port: number) {
+  const server = Bun.serve({
+    port,
+    fetch() {
+      return new Response("busy");
+    },
+  });
+  occupiedPorts.push(server);
+  return server;
+}
+
 afterEach(async () => {
   await stopSupabaseAuthServer();
+  for (const server of occupiedPorts.splice(0)) {
+    server.stop();
+  }
   await Promise.all(cleanupPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
   if (originalBrokerUrl === undefined) {
     process.env.OPENCODE_SUPABASE_BROKER_URL = undefined;
@@ -65,6 +80,7 @@ describe("server auth hook", () => {
           ),
         ) as never,
         logger: createSupabaseLogger({ write }),
+        callbackPorts: [17658, 17659, 17660],
       },
     );
 
@@ -142,6 +158,7 @@ describe("server auth hook", () => {
       },
       {
         logger: createSupabaseLogger({ write }),
+        callbackPorts: [17659, 17660, 17661],
       },
     );
 
@@ -178,6 +195,7 @@ describe("server auth hook", () => {
           queueMicrotask(() => callback());
           return timer;
         }) as typeof setTimeout,
+        callbackPorts: [17660, 17661, 17662],
       },
     );
 
@@ -186,6 +204,92 @@ describe("server auth hook", () => {
 
     const logEntries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
     expect(logEntries.some((entry) => entry.includes("supabase auth callback timed out"))).toBe(true);
+    expect(logEntries.some((entry) => entry.includes("supabase callback server stopped"))).toBe(true);
+  });
+
+  test("falls back to next callback port when base port is busy", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    occupyPort(17670);
+    const write = mock(async () => true);
+    const fetchMock = mock(async (url: string, init?: RequestInit) => {
+      expect(url).toBe("https://example.com/broker/exchange");
+      const body = JSON.parse(String(init?.body));
+      expect(body.redirect_uri).toBe("http://localhost:17671/auth/callback");
+
+      return new Response(
+        JSON.stringify({
+          access_token: "access-123",
+          refresh_token: "refresh-123",
+          expires_in: 1800,
+          token_type: "bearer",
+        }),
+      );
+    });
+
+    const auth = createSupabaseAuth(
+      input as never,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17670,
+      },
+      {
+        fetch: fetchMock as unknown as FetchLike,
+        logger: createSupabaseLogger({ write }),
+        callbackPorts: [17670, 17671, 17672],
+      },
+    );
+
+    const result = await firstAuthMethod(auth).authorize();
+    const authUrl = new URL(result.url);
+    const redirectUri = new URL(requireSearchParam(authUrl, "redirect_uri"));
+    const state = requireSearchParam(authUrl, "state");
+
+    expect(redirectUri.toString()).toBe("http://localhost:17671/auth/callback");
+
+    const pending = result.callback();
+    const response = await fetch(`${redirectUri.toString()}?code=code-123&state=${state}`);
+
+    expect(response.status).toBe(200);
+    await expect(pending).resolves.toMatchObject({
+      type: "success",
+      access: "access-123",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+
+    const logEntries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+    expect(logEntries.some((entry) => entry.includes("supabase callback port probe") && entry.includes('"port":17670'))).toBe(true);
+    expect(logEntries.some((entry) => entry.includes("supabase callback port probe") && entry.includes('"port":17671'))).toBe(true);
+    expect(logEntries.some((entry) => entry.includes("supabase auth started") && entry.includes('"port":17671'))).toBe(true);
+    expect(logEntries.some((entry) => entry.includes("supabase callback server stopped"))).toBe(true);
+  });
+
+  test("fails clearly when callback port window is exhausted", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    occupyPort(17680);
+    occupyPort(17681);
+    occupyPort(17682);
+    const write = mock(async () => true);
+
+    const auth = createSupabaseAuth(
+      input as never,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17680,
+      },
+      {
+        logger: createSupabaseLogger({ write }),
+        callbackPorts: [17680, 17681, 17682],
+      },
+    );
+
+    await expect(firstAuthMethod(auth).authorize()).rejects.toThrow(
+      "Supabase callback ports busy: 17680, 17681, 17682. Close other OpenCode sessions and retry.",
+    );
+
+    const logEntries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+    expect(logEntries.some((entry) => entry.includes("supabase callback port window exhausted"))).toBe(true);
   });
 
   test("builds an auto oauth authorize result using the plugin callback server", async () => {
@@ -208,6 +312,7 @@ describe("server auth hook", () => {
             }),
           ),
         ) as never,
+        callbackPorts: [17654, 17655, 17656],
       },
     );
 
@@ -223,6 +328,41 @@ describe("server auth hook", () => {
     expect(url.searchParams.get("state")).toBeTruthy();
     expect(url.searchParams.get("redirect_uri")).toBe("http://localhost:17654/auth/callback");
     expect(typeof result?.callback).toBe("function");
+  });
+
+  test("uses fixed public callback window even when oauthPort config differs", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    const auth = createSupabaseAuth(
+      input as never,
+      {
+        clientId: "plugin-client",
+        oauthPort: 19999,
+      },
+      {
+        fetch: mock(async () =>
+          new Response(
+            JSON.stringify({
+              access_token: "a",
+              refresh_token: "r",
+              expires_in: 3600,
+              token_type: "bearer",
+            }),
+          ),
+        ) as never,
+      },
+    );
+
+    const result = await firstAuthMethod(auth).authorize();
+    void result.callback().catch(() => undefined);
+    const redirectUri = requireSearchParam(new URL(result.url), "redirect_uri");
+
+    expect([
+      "http://localhost:14589/auth/callback",
+      "http://localhost:14590/auth/callback",
+      "http://localhost:14591/auth/callback",
+    ]).toContain(redirectUri);
+    expect(redirectUri).not.toContain(":19999/");
   });
 
   test("rejects callback requests with missing state", async () => {
@@ -296,7 +436,7 @@ describe("server auth hook", () => {
         clientId: "plugin-client",
         oauthPort: 17656,
       },
-      { fetch: fetchMock as unknown as FetchLike },
+      { fetch: fetchMock as unknown as FetchLike, callbackPorts: [17656, 17657, 17658] },
     );
 
     const result = await firstAuthMethod(auth).authorize();
@@ -328,6 +468,50 @@ describe("server auth hook", () => {
     });
   });
 
+  test("stops callback listener after provider denial when no auth remains", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    const write = mock(async () => true);
+    const auth = createSupabaseAuth(
+      input as never,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17683,
+      },
+      {
+        logger: createSupabaseLogger({ write }),
+        callbackPorts: [17683, 17684, 17685],
+      },
+    );
+
+    const result = await firstAuthMethod(auth).authorize();
+    const redirectUri = new URL(requireSearchParam(new URL(result.url), "redirect_uri"));
+    const state = requireSearchParam(new URL(result.url), "state");
+
+    const pending = result.callback();
+    pending.catch(() => undefined);
+    await fetch(`${redirectUri.toString()}?error=access_denied&error_description=User%20denied&state=${state}`);
+    await expect(pending).rejects.toThrow("User denied");
+
+    const nextAuth = createSupabaseAuth(
+      input as never,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17683,
+      },
+      {
+        logger: createSupabaseLogger({ write }),
+        callbackPorts: [17683, 17684, 17685],
+      },
+    );
+    const nextResult = await firstAuthMethod(nextAuth).authorize();
+    void nextResult.callback().catch(() => undefined);
+    expect(nextResult).toBeTruthy();
+
+    const logEntries = write.mock.calls.map((call) => JSON.stringify(((call as unknown) as [unknown])[0]));
+    expect(logEntries.some((entry) => entry.includes("supabase callback server stopped"))).toBe(true);
+  });
+
   test("persists oauth auth under the session directory when host worktree resolves to root", async () => {
     const input = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
@@ -348,7 +532,7 @@ describe("server auth hook", () => {
         clientId: "plugin-client",
         oauthPort: 17661,
       },
-      { fetch: fetchMock as unknown as FetchLike },
+      { fetch: fetchMock as unknown as FetchLike, callbackPorts: [17661, 17662, 17663] },
     );
 
     const result = await firstAuthMethod(auth).authorize();
@@ -399,7 +583,7 @@ describe("server auth hook", () => {
         clientId: "plugin-client",
         oauthPort: 17662,
       },
-      { fetch: fetchMock as unknown as FetchLike },
+      { fetch: fetchMock as unknown as FetchLike, callbackPorts: [17662, 17663, 17664] },
     );
 
     const result = await firstAuthMethod(auth).authorize();

--- a/test/shared-modules.test.ts
+++ b/test/shared-modules.test.ts
@@ -35,7 +35,7 @@ describe("shared config", () => {
 
     expect(config).toEqual({
       clientId: "plugin-client",
-      oauthPort: 1456,
+      oauthPort: DEFAULT_SUPABASE_OAUTH_PORT,
       authorizeUrl: DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL,
       brokerBaseUrl: "https://example.com/env-broker",
       apiBaseUrl: DEFAULT_SUPABASE_API_BASE_URL,
@@ -68,7 +68,7 @@ describe("shared config", () => {
 
     expect(config).toEqual({
       clientId: "env-client",
-      oauthPort: 4567,
+      oauthPort: DEFAULT_SUPABASE_OAUTH_PORT,
       authorizeUrl: "https://example.com/authorize",
       brokerBaseUrl: "https://example.com/broker",
       apiBaseUrl: "https://example.com/api",
@@ -98,22 +98,23 @@ describe("shared config", () => {
     expect(config.brokerBaseUrl).toBe("https://iaoxncwzemnfxcdwakzb.supabase.co/functions/v1/opencode-supabase-broker");
   });
 
-  test("uses the default oauth port and rejects invalid env ports", () => {
+  test("uses the fixed default oauth port regardless of overrides", () => {
     expect(
       readSupabaseConfig(
         {
           clientId: "plugin-client",
+          oauthPort: 9999,
         },
         {},
       ).oauthPort,
     ).toBe(DEFAULT_SUPABASE_OAUTH_PORT);
 
-    expect(() =>
+    expect(
       readSupabaseConfig(undefined, {
         OPENCODE_SUPABASE_OAUTH_CLIENT_ID: "env-client",
         OPENCODE_SUPABASE_OAUTH_PORT: "abc",
-      }),
-    ).toThrow("Invalid Supabase config: oauthPort must be a positive integer");
+      }).oauthPort,
+    ).toBe(DEFAULT_SUPABASE_OAUTH_PORT);
   });
 });
 

--- a/test/supabase-broker.test.ts
+++ b/test/supabase-broker.test.ts
@@ -115,6 +115,86 @@ describe("supabase broker exchange", () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
+  test("accepts fallback localhost callback ports in same plugin path", async () => {
+    const fetchMock = mock(async (input: string | URL | Request, init?: RequestInit) => {
+      expect(String(input)).toBe("https://api.supabase.com/v1/oauth/token");
+
+      const body = new URLSearchParams(String(init?.body));
+      expect(body.get("redirect_uri")).toBe("http://localhost:14590/auth/callback");
+
+      return Response.json(
+        {
+          access_token: "access-14590",
+          refresh_token: "refresh-14590",
+          expires_in: 3600,
+          token_type: "bearer",
+        } satisfies TokenResponse,
+        { status: 200 },
+      );
+    });
+
+    const response = await handleExchangeRequest(
+      new Request("http://localhost:54321/exchange", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "code-14590",
+          code_verifier: "verifier-14590",
+          redirect_uri: "http://localhost:14590/auth/callback",
+        }),
+      }),
+      baseConfig,
+      fetchMock,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      access_token: "access-14590",
+      refresh_token: "refresh-14590",
+      expires_in: 3600,
+      token_type: "bearer",
+    });
+  });
+
+  test("accepts third fixed localhost callback port in plugin path", async () => {
+    const fetchMock = mock(async (_input: string | URL | Request, init?: RequestInit) => {
+      const body = new URLSearchParams(String(init?.body));
+      expect(body.get("redirect_uri")).toBe("http://localhost:14591/auth/callback");
+
+      return Response.json(
+        {
+          access_token: "access-14591",
+          refresh_token: "refresh-14591",
+          expires_in: 3600,
+          token_type: "bearer",
+        } satisfies TokenResponse,
+        { status: 200 },
+      );
+    });
+
+    const response = await handleExchangeRequest(
+      new Request("http://localhost:54321/exchange", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          code: "code-14591",
+          code_verifier: "verifier-14591",
+          redirect_uri: "http://localhost:14591/auth/callback",
+        }),
+      }),
+      baseConfig,
+      fetchMock,
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      access_token: "access-14591",
+      refresh_token: "refresh-14591",
+      expires_in: 3600,
+      token_type: "bearer",
+    });
+  });
+
   test("routes function-prefixed exchange paths used by Supabase local serve", async () => {
     const fetchMock = mock(async () => {
       return Response.json(


### PR DESCRIPTION
## Summary
- retry Supabase browser auth across fixed callback ports `14589`, `14590`, and `14591`
- stop callback listener immediately when no auth requests remain and surface clearer busy-port errors and logs
- add regression coverage, docs, and changeset for fixed callback contract

## Test Plan
- [x] bun test test/server-auth.test.ts
- [x] bun test test/shared-modules.test.ts
- [x] bun run typecheck
- [x] bun run lint
- [x] bun test