### PR TITLE
fix(ci): run checks for release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,25 +43,27 @@ jobs:
 
   changeset-check:
     runs-on: ubuntu-latest
+    env:
+      SHOULD_RUN_CHANGESET_CHECK: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
       - name: Checkout
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/')
+        if: env.SHOULD_RUN_CHANGESET_CHECK == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/')
+        if: env.SHOULD_RUN_CHANGESET_CHECK == 'true'
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
 
       - name: Install dependencies
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/')
+        if: env.SHOULD_RUN_CHANGESET_CHECK == 'true'
         run: bun install --frozen-lockfile
 
       - name: Check for changeset
-        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/')
+        if: env.SHOULD_RUN_CHANGESET_CHECK == 'true'
         run: bunx changeset status --since=origin/main
 
   plugin-smoke:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,7 @@ jobs:
   changeset-check:
     runs-on: ubuntu-latest
     env:
+      # Keep the required job green on release/no-changeset PRs while only running the real check for normal PRs.
       SHOULD_RUN_CHANGESET_CHECK: ${{ github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/') }}
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,7 @@ on:
   push:
     branches:
       - main
+      - changeset-release/**
   workflow_dispatch:
 
 jobs:
@@ -42,22 +43,25 @@ jobs:
 
   changeset-check:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/')
     steps:
       - name: Checkout
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/')
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Bun
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/')
         uses: oven-sh/setup-bun@v2
         with:
           bun-version: 1.3.11
 
       - name: Install dependencies
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/')
         run: bun install --frozen-lockfile
 
       - name: Check for changeset
+        if: github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-changeset') && !startsWith(github.head_ref, 'changeset-release/')
         run: bunx changeset status --since=origin/main
 
   plugin-smoke:


### PR DESCRIPTION
## Summary
- run the CI workflow on `changeset-release/**` pushes so changesets-created release branches report the required `core` status
- move the `changeset-check` gating from the job to its steps so the required check always reports a result, including on release PRs
- keep branch protection unchanged while unblocking release PRs like #20