### PR TITLE
fix(ci): use fine-grained PAT for changesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,15 @@ jobs:
         with:
           token: ${{ secrets.CHANGESETS_TOKEN }}
 
+      - name: Verify CHANGESETS_TOKEN
+        run: |
+          if [ -z "$CHANGESETS_TOKEN" ]; then
+            echo "::error::CHANGESETS_TOKEN secret is missing or empty. See docs/releasing.md > One-Time Setup > GitHub."
+            exit 1
+          fi
+        env:
+          CHANGESETS_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
+
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.CHANGESETS_TOKEN }}
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
@@ -39,5 +41,5 @@ jobs:
           version: bun run version-packages
           publish: bun run release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.CHANGESETS_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -54,6 +54,12 @@ Quick validation before first release:
 
 ### GitHub
 
+- Create a fine-grained personal access token for changesets:
+  - Go to GitHub Settings > Developer settings > Fine-grained tokens
+  - Repository access: only this repository
+  - Permissions: Contents (read and write), Pull requests (read and write), Metadata (read)
+  - Add the token as GitHub Actions secret `CHANGESETS_TOKEN`
+  - Why: `GITHUB_TOKEN` pushes from GitHub Actions do not trigger other workflows. The changesets release PR would never get CI checks without a separate token. See [GitHub docs on GITHUB_TOKEN limitations](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs).
 - Create required labels:
   - `no-changeset` for PRs that should skip Changesets enforcement
 - Protect `main`
@@ -216,6 +222,13 @@ Future hardening:
 - add a real changeset with `bun run changeset`
 - or apply `no-changeset` if the PR truly has no consumer-visible impact
 
+### Release PR has no CI checks
+
+- `GITHUB_TOKEN` pushes do not trigger workflows — this is a GitHub Actions limitation
+- ensure `CHANGESETS_TOKEN` fine-grained PAT is set in repository secrets
+- ensure `release.yml` uses `CHANGESETS_TOKEN` for both `actions/checkout` and `changesets/action`
+- re-trigger the Release workflow after fixing the secret
+
 ### Bad release PR contents
 
 - do not merge
@@ -237,6 +250,11 @@ When the repo moves:
 - verify GitHub Actions remain enabled
 - verify the default branch is still `main`
 - recreate or rotate `NPM_TOKEN`
+- recreate `CHANGESETS_TOKEN` fine-grained PAT (the old token is scoped to the original repo and will not transfer):
+  - create a new fine-grained PAT in the new org or by a new org maintainer
+  - repository access: only this repository
+  - permissions: Contents (read and write), Pull requests (read and write), Metadata (read)
+  - store as GitHub Actions secret `CHANGESETS_TOKEN`
 - recreate required labels if missing:
   - `no-changeset`
 - reapply branch protection rules
@@ -286,6 +304,7 @@ EOF
 
 - Changesets setup branch merged
 - `NPM_TOKEN` configured
+- `CHANGESETS_TOKEN` configured
 - `no-changeset` label exists
 - branch protection configured
 - real bugfix PR includes a real changeset

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -57,9 +57,25 @@ Quick validation before first release:
 - Create a fine-grained personal access token for changesets:
   - Go to GitHub Settings > Developer settings > Fine-grained tokens
   - Repository access: only this repository
-  - Permissions: Contents (read and write), Pull requests (read and write), Metadata (read)
+  - Token expiration: maximum allowed (1 year). Set a calendar reminder to renew at ~10 months.
+  - Permissions:
+
+    | Permission    | Access       | Why                                                      |
+    | ------------- | ------------ | -------------------------------------------------------- |
+    | Contents      | Read and write | Checkout, push version commits, create release PR branch |
+    | Pull requests | Read and write | Create and update the Version Packages PR                |
+    | Metadata      | Read         | Required by GitHub for all API access                    |
+
+    Note: The "Workflows" permission is **not** needed. Only the built-in `GITHUB_TOKEN` cannot trigger other workflows; a PAT push triggers CI automatically.
+
   - Add the token as GitHub Actions secret `CHANGESETS_TOKEN`
   - Why: `GITHUB_TOKEN` pushes from GitHub Actions do not trigger other workflows. The changesets release PR would never get CI checks without a separate token. See [GitHub docs on GITHUB_TOKEN limitations](https://docs.github.com/en/actions/concepts/security/github_token#when-github_token-triggers-workflow-runs).
+  - Ownership: the token is tied to the GitHub account that created it. If that account leaves the org or is deactivated, the token stops working immediately. Prefer creating the token from a shared bot account or a team-owned account. If neither is available, document which maintainer owns the token and track renewal in a shared calendar.
+  - Renewal steps:
+    1. Create a new fine-grained PAT with the same permissions listed above.
+    2. Update the `CHANGESETS_TOKEN` GitHub Actions secret with the new value.
+    3. Delete the old token in GitHub Settings > Developer settings > Fine-grained tokens.
+    4. Re-trigger the Release workflow to verify the new token works.
 - Create required labels:
   - `no-changeset` for PRs that should skip Changesets enforcement
 - Protect `main`
@@ -225,9 +241,8 @@ Future hardening:
 ### Release PR has no CI checks
 
 - `GITHUB_TOKEN` pushes do not trigger workflows — this is a GitHub Actions limitation
-- ensure `CHANGESETS_TOKEN` fine-grained PAT is set in repository secrets
-- ensure `release.yml` uses `CHANGESETS_TOKEN` for both `actions/checkout` and `changesets/action`
-- re-trigger the Release workflow after fixing the secret
+- Verify `CHANGESETS_TOKEN` is configured correctly (see [One-Time Setup > GitHub](#github))
+- Re-trigger the Release workflow after fixing the secret
 
 ### Bad release PR contents
 
@@ -250,11 +265,7 @@ When the repo moves:
 - verify GitHub Actions remain enabled
 - verify the default branch is still `main`
 - recreate or rotate `NPM_TOKEN`
-- recreate `CHANGESETS_TOKEN` fine-grained PAT (the old token is scoped to the original repo and will not transfer):
-  - create a new fine-grained PAT in the new org or by a new org maintainer
-  - repository access: only this repository
-  - permissions: Contents (read and write), Pull requests (read and write), Metadata (read)
-  - store as GitHub Actions secret `CHANGESETS_TOKEN`
+- recreate `CHANGESETS_TOKEN` fine-grained PAT (the old token is scoped to the original repo and will not transfer); see [One-Time Setup > GitHub](#github) for required permissions and creation steps
 - recreate required labels if missing:
   - `no-changeset`
 - reapply branch protection rules


### PR DESCRIPTION
## Summary

- Switch `release.yml` from `GITHUB_TOKEN` to `CHANGESETS_TOKEN` (fine-grained PAT) for `actions/checkout` and `changesets/action`
- `GITHUB_TOKEN` pushes don't trigger other workflows, so release PRs never get CI checks
- Update `docs/releasing.md` with PAT setup instructions, transfer checklist, first release checklist, and failure handling

## Manual steps required after merge

1. Create a fine-grained PAT at GitHub Settings > Developer settings > Fine-grained tokens
2. Permissions: Contents (write), Pull requests (write), Metadata (read)
3. Repository access: this repo only
4. Add as repo secret `CHANGESETS_TOKEN`
5. Re-trigger the Release workflow to verify PR #20 gets CI checks

Closes #20 (unblocks the Version Packages PR)