### PR TITLE
feat: add supabase_list_regions tool

### DIFF
--- a/.changeset/warm-dots-list-regions.md
+++ b/.changeset/warm-dots-list-regions.md
@@ -1,0 +1,5 @@
+---
+'opencode-supabase': patch
+---
+
+Add `supabase_list_regions` tool — calls `GET /v1/regions` so the LLM can discover valid region codes before creating projects.

--- a/.changeset/warm-dots-list-regions.md
+++ b/.changeset/warm-dots-list-regions.md
@@ -2,4 +2,4 @@
 'opencode-supabase': patch
 ---
 
-Add `supabase_list_regions` tool — calls `GET /v1/regions` so the LLM can discover valid region codes before creating projects.
+Add `supabase_list_regions` tool — calls `GET /v1/projects/available-regions?organization_slug=<slug>` so the LLM can discover valid region codes before creating projects.

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -256,6 +256,23 @@ export function createSupabaseTools(
         );
       },
     }),
+    supabase_list_regions: tool({
+      description: "List all available database regions for creating a Supabase project in a specific organization.",
+      args: {
+        organization_slug: tool.schema.string().describe("Organization slug to list regions for"),
+      },
+      async execute(args, _context: SupabaseToolContext) {
+        return executeSupabaseGet(
+          input,
+          options,
+          deps,
+          "supabase_list_regions",
+          _context,
+          `/projects/available-regions?organization_slug=${encodeURIComponent(args.organization_slug)}`,
+          "list regions",
+        );
+      },
+    }),
     supabase_get_project_api_keys: tool({
       description: "Get the API keys for a Supabase project.",
       args: {

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -1101,6 +1101,75 @@ describe("server tools auth helper", () => {
     ).rejects.toThrow("Failed to create project: 400 bad request");
   });
 
+  test("fetches available regions for an organization", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      expect(url).toBe("https://api.supabase.com/v1/projects/available-regions?organization_slug=my-org");
+      expect(init?.headers).toMatchObject({
+        Authorization: "Bearer saved-access",
+        Accept: "application/json",
+      });
+
+      return new Response(JSON.stringify({
+        recommendations: { smartGroup: [], specific: [] },
+        all: {
+          smartGroup: [{ name: "Americas", code: "americas" }],
+          specific: [{ name: "US East (North Virginia)", code: "us-east-1", type: "specific", provider: "AWS" }],
+        },
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17690,
+      },
+      { fetch: fetchMock },
+    );
+
+    const result = await tools.supabase_list_regions.execute({ organization_slug: "my-org" }, createContext(input));
+
+    expect(result).toContain("us-east-1");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("formats regions API failures clearly", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async () => new Response("nope", { status: 403 }));
+
+    const tools = createSupabaseTools(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17691,
+      },
+      { fetch: fetchMock },
+    );
+
+    await expect(
+      tools.supabase_list_regions.execute({ organization_slug: "my-org" }, createContext(input)),
+    ).rejects.toThrow("Failed to list regions: 403 nope");
+  });
+
   test("supabase_login returns TUI guidance", async () => {
     const { input } = await createInput();
 


### PR DESCRIPTION
## Summary

- Adds `supabase_list_regions` tool calling `GET /v1/regions`, following the same `executeSupabaseGet` pattern as `list_organizations` and `list_projects`
- LLM can now discover valid region codes before calling `supabase_create_project` instead of relying on the hardcoded `us-east-1` default
- Includes success test (validates URL, headers, response) and error-formatting test (validates `"Failed to list regions: <status> <body>"` message shape)

## Test plan

- [x] `bun test` — 93 pass (2 new)
- [x] `bunx tsc --noEmit` — clean
- [x] `bunx biome check .` — clean