### PR TITLE
feat: add connected-state preflight and disconnect to /supabase

### DIFF
--- a/.changeset/lovely-showers-win.md
+++ b/.changeset/lovely-showers-win.md
@@ -1,0 +1,20 @@
+---
+"opencode-supabase": minor
+---
+
+## Features
+
+- **Connected-state detection**: `/supabase` now checks saved auth before showing the connect dialog. If already connected, shows "Already connected to Supabase" with options to continue or disconnect.
+- **Disconnect action**: Added ability to disconnect from Supabase via the already-connected dialog.
+- **Auth status preflight**: Dialog now shows "Checking Supabase connection..." while verifying auth state.
+
+## Fixes
+
+- **Preflight deduplication**: Prevent duplicate auth status checks when dialog re-renders.
+- **Broker refresh single-flight**: Concurrent stale-auth callers now join one broker refresh instead of spawning multiple.
+- **Disconnect race protection**: Explicit disconnect wins over in-flight refresh operations.
+- **Stale refresh handling**: Refreshes that complete after newer auth is written no longer overwrite or clear the newer credentials.
+
+## UI Improvements
+
+- **Disconnect label**: Already-connected dialog cancel button now explicitly labeled "Disconnect" instead of generic "Cancel".

--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ report.[0-9]_.[0-9]_.[0-9]_.[0-9]_.json
 .mise.toml
 supabase/.branches
 supabase/.temp/
+
+# git worktrees
+.worktrees/

--- a/docs/superpowers/plans/2026-04-24-supabase-connected-state.md
+++ b/docs/superpowers/plans/2026-04-24-supabase-connected-state.md
@@ -1,0 +1,429 @@
+# Supabase Connected-State Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `/supabase` auth preflight so already-connected users see connected or unknown-state dialogs instead of always entering the first-run connect flow.
+
+**Architecture:** Keep auth truth on the server side by extending the Supabase auth provider with an additional indexed OAuth method dedicated to status and disconnect operations, while preserving method `0` for the existing interactive OAuth flow. Update the TUI dialog state machine to call the status method on open, surface `checking_auth` only during refresh, and route `Disconnect`, `Retry`, and `Continue` through explicit dialog states backed by the server helper in `src/server/tools.ts`.
+
+**Tech Stack:** TypeScript, Bun test runner, OpenCode plugin server/TUI APIs, Solid signal state, existing Supabase broker refresh helpers.
+
+---
+
+## File Structure
+
+- Modify: `src/server/tools.ts`
+  - add a reusable auth-status evaluator and disconnect helper that share store resolution, refresh, and cleanup behavior with tool auth
+- Modify: `src/server/auth.ts`
+  - add a second OAuth method for status/disconnect operations without changing method `0`
+- Modify: `src/tui/dialog.tsx`
+  - add preflight flow, new dialog states, and actions for retry/continue/disconnect
+- Modify: `test/server-tools.test.ts`
+  - add direct coverage for connected/disconnected/unknown/disconnect helper behavior
+- Modify: `test/plugin-exports.test.ts`
+  - add TUI coverage for connected-state dialogs and action routing
+
+### Task 1: Add Server-Side Auth Status Helpers
+
+**Files:**
+- Modify: `src/server/tools.ts`
+- Test: `test/server-tools.test.ts`
+
+- [ ] **Step 1: Write the failing server-helper tests**
+
+Add these tests to `test/server-tools.test.ts` near the existing `ensureSupabaseToolAuth` coverage:
+
+```ts
+test("reports connected when saved auth is still fresh", async () => {
+  const { input } = await createInput();
+  await writeSavedAuth(input, {
+    access: "saved-access",
+    refresh: "saved-refresh",
+    expires: Date.now() + 60_000,
+  });
+
+  await expect(getSupabaseAuthStatus(input)).resolves.toEqual({
+    status: "connected",
+    auth: {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: expect.any(Number),
+    },
+    checked: false,
+  });
+});
+
+test("reports unknown when refresh fails for broker availability reasons", async () => {
+  const { input } = await createInput();
+  process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+  await writeSavedAuth(input, {
+    access: "expired-access",
+    refresh: "saved-refresh",
+    expires: Date.now() - 1_000,
+  });
+
+  const fetchMock: FetchLike = mock(async (request) => {
+    const url = String(request);
+    if (url === "https://example.com/broker/refresh") {
+      return new Response(
+        JSON.stringify({
+          error: { code: "broker_unavailable", message: "broker unavailable" },
+        }),
+        { status: 502, headers: { "Content-Type": "application/json" } },
+      );
+    }
+
+    throw new Error(`unexpected url: ${url}`);
+  });
+
+  await expect(getSupabaseAuthStatus(input, undefined, { fetch: fetchMock })).resolves.toEqual({
+    status: "unknown",
+    checked: true,
+    message: "Supabase auth refresh failed: broker unavailable",
+  });
+});
+
+test("disconnect helper clears saved auth and host auth", async () => {
+  const { input } = await createInput();
+  process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+  await writeSavedAuth(input, {
+    access: "saved-access",
+    refresh: "saved-refresh",
+    expires: Date.now() + 60_000,
+  });
+
+  const fetchMock: FetchLike = mock(async (request) => {
+    const url = String(request);
+    if (url === `http://127.0.0.1:7777/auth/supabase?directory=${encodeURIComponent(input.directory)}`) {
+      return new Response(JSON.stringify(true), {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    }
+
+    throw new Error(`unexpected url: ${url}`);
+  });
+
+  await disconnectSupabaseAuth(input, { fetch: fetchMock });
+
+  await expect(readSavedAuth(input)).resolves.toEqual({ version: 1 });
+});
+```
+
+- [ ] **Step 2: Run server helper tests to verify they fail**
+
+Run: `bun test test/server-tools.test.ts`
+Expected: FAIL with missing exports for `getSupabaseAuthStatus` and `disconnectSupabaseAuth`
+
+- [ ] **Step 3: Implement the shared auth-status and disconnect helpers**
+
+Update `src/server/tools.ts` with these additions near the existing auth helpers:
+
+```ts
+export type SupabaseAuthStatus =
+  | {
+      status: "connected";
+      auth: SavedAuth;
+      checked: boolean;
+    }
+  | {
+      status: "disconnected";
+      checked: boolean;
+    }
+  | {
+      status: "unknown";
+      checked: true;
+      message: string;
+    };
+
+export async function disconnectSupabaseAuth(
+  input: SupabaseToolInput,
+  deps: Pick<ToolDeps, "fetch"> = {},
+) {
+  const fetchImpl = deps.fetch ?? fetch;
+  await clearSavedAuth(input);
+  try {
+    await clearHostAuth(input, fetchImpl);
+  } catch {}
+}
+
+export async function getSupabaseAuthStatus(
+  input: SupabaseToolInput,
+  options?: PluginOptions,
+  deps: ToolDeps = {},
+): Promise<SupabaseAuthStatus> {
+  const saved = await readSavedAuth(input);
+  if (!saved.auth) {
+    return { status: "disconnected", checked: false };
+  }
+
+  if (!isRefreshNeeded(saved.auth)) {
+    return { status: "connected", auth: saved.auth, checked: false };
+  }
+
+  try {
+    const auth = await ensureSupabaseToolAuth(input, options, deps);
+    return { status: "connected", auth, checked: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === NOT_CONNECTED_MESSAGE) {
+      return { status: "disconnected", checked: true };
+    }
+    return { status: "unknown", checked: true, message };
+  }
+}
+```
+
+- [ ] **Step 4: Run server helper tests to verify they pass**
+
+Run: `bun test test/server-tools.test.ts`
+Expected: PASS for new helper tests and existing auth-helper coverage
+
+- [ ] **Step 5: Commit the server helper slice**
+
+```bash
+git add src/server/tools.ts test/server-tools.test.ts
+git commit -m "feat(auth): add connected-state status helper"
+```
+
+### Task 2: Expose Status and Disconnect Through the Auth Provider
+
+**Files:**
+- Modify: `src/server/auth.ts`
+- Test: `test/plugin-exports.test.ts`
+
+- [ ] **Step 1: Write the failing auth-provider method test**
+
+Add a focused test to `test/plugin-exports.test.ts`:
+
+```ts
+test("server auth provider exposes connect and status methods", async () => {
+  const mod = await import("../src/server/auth.ts");
+  const provider = mod.createSupabaseAuth(
+    {
+      directory: "/tmp/project",
+      worktree: "/tmp/project",
+    },
+    undefined,
+    {},
+  );
+
+  expect(provider.methods).toHaveLength(2);
+  expect(provider.methods[0]).toMatchObject({ type: "oauth", label: "Supabase" });
+  expect(provider.methods[1]).toMatchObject({ type: "oauth", label: "Supabase Status" });
+});
+```
+
+- [ ] **Step 2: Run plugin tests to verify they fail**
+
+Run: `bun test test/plugin-exports.test.ts`
+Expected: FAIL because only one auth method exists
+
+- [ ] **Step 3: Add the second provider method backed by the new helpers**
+
+Update `src/server/auth.ts` imports and `methods` array to include a status/disconnect method:
+
+```ts
+import { disconnectSupabaseAuth, getSupabaseAuthStatus } from "./tools.ts";
+```
+
+```ts
+      {
+        type: "oauth" as const,
+        label: "Supabase Status",
+        async authorize() {
+          return {
+            url: "about:blank",
+            instructions: "Check Supabase auth status.",
+            method: "manual" as const,
+            callback: async () => {
+              const status = await getSupabaseAuthStatus({
+                ...input,
+                client: {
+                  auth: {
+                    set: async () => true,
+                  },
+                },
+                serverUrl: new URL("http://127.0.0.1/"),
+              } as never, options, deps as never);
+
+              return {
+                type: "success" as const,
+                access: JSON.stringify(status),
+                refresh: "",
+                expires: 0,
+              };
+            },
+          };
+        },
+      },
+```
+
+Then refine the method shape so the callback payload cleanly encodes either `status` or `disconnect` operation without starting browser auth.
+
+- [ ] **Step 4: Run plugin tests to verify they pass**
+
+Run: `bun test test/plugin-exports.test.ts`
+Expected: PASS for provider method count and no regression in existing dialog tests
+
+- [ ] **Step 5: Commit the provider bridge slice**
+
+```bash
+git add src/server/auth.ts test/plugin-exports.test.ts
+git commit -m "feat(auth): expose status bridge to tui"
+```
+
+### Task 3: Add TUI Preflight States and Actions
+
+**Files:**
+- Modify: `src/tui/dialog.tsx`
+- Test: `test/plugin-exports.test.ts`
+
+- [ ] **Step 1: Write the failing TUI dialog tests**
+
+Add these tests to `test/plugin-exports.test.ts` using the existing `createDialogApi` helper:
+
+```ts
+test("supabase dialog shows already connected when status check returns connected", async () => {
+  const api = createDialogApi({
+    client: {
+      app: { log: (_input: unknown) => Promise.resolve(true) },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method: number }) => {
+            if (method === 1) {
+              return Promise.resolve({ data: { url: "about:blank", instructions: "status", method: "manual" } });
+            }
+            return Promise.resolve({ data: { url: "https://example.com/auth", instructions: "oauth", method: "manual" } });
+          },
+          callback: ({ method }: { method: number }) => {
+            if (method === 1) {
+              return Promise.resolve({ data: JSON.stringify({ status: "connected", checked: false }) });
+            }
+            return Promise.resolve({ data: true });
+          },
+        },
+      },
+    },
+  });
+
+  SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "checking_auth" },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 0));
+
+  const dialog = api.__test.dialogConfirms.at(-1) as { title?: string; message?: string };
+  expect(dialog.title).toBe("Already connected to Supabase");
+});
+```
+
+Also add cases for:
+
+- showing `Checking Supabase connection...` while status callback is pending and requires refresh
+- showing the existing connect dialog when status returns `disconnected`
+- showing the unknown-state dialog when status returns `unknown`
+- `Disconnect` clearing auth through method `1`
+- `Retry` rerunning the preflight from `unknown`
+
+- [ ] **Step 2: Run plugin dialog tests to verify they fail**
+
+Run: `bun test test/plugin-exports.test.ts`
+Expected: FAIL because `checking_auth`, `already_connected`, and `unknown_auth` do not exist yet
+
+- [ ] **Step 3: Implement the dialog preflight and actions**
+
+Update `src/tui/dialog.tsx` to:
+
+```ts
+type OAuthState =
+  | { type: "checking_auth" }
+  | { type: "idle" }
+  | { type: "already_connected" }
+  | { type: "unknown_auth"; message: string }
+  | { type: "authorizing"; url: string }
+  | { type: "waiting_callback"; url: string }
+  | { type: "success" }
+  | { type: "error"; message: string; url?: string };
+```
+
+Add helpers for the status bridge and disconnect action:
+
+```ts
+async function runStatusCheck(api: TuiPluginApi) {
+  const authResponse = await api.client.provider.oauth.authorize({
+    providerID: "supabase",
+    method: 1,
+  });
+  if (authResponse.error) throw authResponse.error;
+
+  const callbackResponse = await api.client.provider.oauth.callback({
+    providerID: "supabase",
+    method: 1,
+  });
+  if (callbackResponse.error) throw callbackResponse.error;
+
+  return JSON.parse(String(callbackResponse.data)) as {
+    status: "connected" | "disconnected" | "unknown";
+    checked: boolean;
+    message?: string;
+  };
+}
+```
+
+Then:
+
+- run preflight on open when initial state is absent
+- show `checking_auth` only after a status result indicates `checked: true` or while the callback is pending
+- map status results to `already_connected`, `idle`, or `unknown_auth`
+- wire `Disconnect` to the method `1` bridge and return to `idle`
+- keep existing OAuth success and retry behavior unchanged for method `0`
+
+- [ ] **Step 4: Run plugin dialog tests to verify they pass**
+
+Run: `bun test test/plugin-exports.test.ts`
+Expected: PASS for new connected-state dialog coverage and existing OAuth dialog coverage
+
+- [ ] **Step 5: Commit the TUI slice**
+
+```bash
+git add src/tui/dialog.tsx test/plugin-exports.test.ts
+git commit -m "feat(tui): add supabase auth preflight dialogs"
+```
+
+### Task 4: Final Verification
+
+**Files:**
+- Modify: `docs/superpowers/plans/2026-04-24-supabase-connected-state.md`
+
+- [ ] **Step 1: Run focused tests together**
+
+Run: `bun test test/server-tools.test.ts test/plugin-exports.test.ts`
+Expected: PASS
+
+- [ ] **Step 2: Run full repo verification**
+
+Run: `bun test && bunx tsc --noEmit && biome check .`
+Expected: PASS with zero test failures, zero type errors, zero Biome errors
+
+- [ ] **Step 3: Update this plan checklist as tasks complete**
+
+Mark completed checkboxes in this file as you execute the work.
+
+- [ ] **Step 4: Commit the final implementation**
+
+```bash
+git add src/server/auth.ts src/server/tools.ts src/tui/dialog.tsx test/server-tools.test.ts test/plugin-exports.test.ts docs/superpowers/plans/2026-04-24-supabase-connected-state.md
+git commit -m "feat: add supabase connected-state preflight"
+```

--- a/docs/superpowers/specs/2026-04-24-supabase-connected-state-design.md
+++ b/docs/superpowers/specs/2026-04-24-supabase-connected-state-design.md
@@ -1,0 +1,162 @@
+# `/supabase` Connected-State Preflight Design
+
+## Summary
+
+When a user runs `/supabase`, the dialog should first determine whether usable Supabase auth already exists. Users who are already connected should see that state immediately instead of being pushed back through the first-run OAuth flow.
+
+This design keeps auth truth on the server side, reuses the existing saved-auth and refresh policy, and adds explicit UI for three outcomes: connected, disconnected, and unknown.
+
+## Goals
+
+- Show a clear connected state for users who already have usable auth.
+- Reuse the same freshness and refresh semantics already used by tool execution.
+- Provide visible feedback when the dialog needs to refresh auth.
+- Handle broker and network failures without incorrectly forcing a disconnect.
+- Keep the implementation minimal and aligned with current TUI patterns.
+
+## Non-Goals
+
+- Force a refresh on every `/supabase` open.
+- Make a Supabase Management API call on every `/supabase` open.
+- Detect remote revocation for still-fresh access tokens.
+- Add a separate `/supabase-disconnect` command.
+- Change the existing OAuth authorize/callback contract into a generic status API.
+
+## Connected-State Semantics
+
+The dialog should classify auth into one of three states.
+
+### Connected
+
+A user is connected when saved auth exists and one of these is true:
+
+- the saved access token is still fresh under the same policy used by `ensureSupabaseToolAuth(...)`
+- the access token is stale but refresh succeeds
+
+### Disconnected
+
+A user is disconnected when one of these is true:
+
+- no saved auth exists
+- refresh returns unauthorized (`400` or `401`) and the existing cleanup path clears local auth
+
+### Unknown
+
+A user is in an unknown state when saved auth exists but verification cannot complete because the broker or network is unavailable.
+
+This preserves an important distinction: failure to verify is not the same thing as confirmed disconnection.
+
+## User Experience
+
+When `/supabase` opens, the dialog should run an auth preflight before showing the current connect confirmation.
+
+The preflight has three outcomes:
+
+- `connected`: show `Already connected to Supabase` with actions `Disconnect` and `Continue`
+- `disconnected`: show the existing connect confirmation dialog
+- `unknown`: show `Saved Supabase login found, but couldn't verify it right now.` with actions `Retry`, `Continue`, and `Disconnect`
+
+Action semantics:
+
+- `Continue` from `already_connected` closes the dialog and leaves the current saved auth untouched.
+- `Retry` from `unknown` reruns the auth preflight.
+- `Continue` from `unknown` closes the dialog, leaves saved auth untouched, and lets later tool execution determine whether auth is still usable.
+
+## Loading Feedback
+
+If the preflight completes from the saved auth state without needing a refresh, the dialog should not show an extra loading step.
+
+If the preflight needs a refresh, the dialog should temporarily show a built-in alert with copy such as `Checking Supabase connection...`.
+
+This loading state should reuse the existing centered `DialogAlert` pattern already used by the dialog's waiting states rather than introducing a custom dialog shell.
+
+## Architecture
+
+Auth-state truth must remain server-side. The TUI must not inspect `.opencode/supabase-auth.json` directly.
+
+The implementation should add a small server-side auth-status helper that reuses the same store resolution and refresh policy as `ensureSupabaseToolAuth(...)`. That helper should return one of three outcomes:
+
+- `connected`
+- `disconnected`
+- `unknown`
+
+The existing OAuth `authorize()` and `callback()` contract should remain focused on starting interactive OAuth and should not be overloaded with connected-state detection.
+
+## Proposed Component Changes
+
+### TUI
+
+`src/tui/dialog.tsx` should add three dialog states:
+
+- `checking_auth`
+- `already_connected`
+- `unknown_auth`
+
+The `checking_auth` state exists only for the refresh path and should not appear for fast local decisions.
+
+The dialog flow should become:
+
+1. Start auth preflight when `/supabase` opens.
+2. If saved auth is fresh, show `already_connected`.
+3. If saved auth requires refresh, show `checking_auth` while verification runs.
+4. If refresh succeeds, show `already_connected`.
+5. If no saved auth exists, show the existing connect dialog.
+6. If refresh returns unauthorized, clear auth through the existing path and show the disconnected connect dialog.
+7. If refresh cannot complete because of broker or network failure, show `unknown_auth`.
+
+### Server
+
+The server should expose a small helper that evaluates current auth status using existing store and refresh behavior.
+
+This helper should:
+
+1. Read saved auth using the current store-path resolution logic.
+2. Return `disconnected` when saved auth does not exist.
+3. Return `connected` when saved auth exists and is still fresh.
+4. Attempt refresh when saved auth is present but stale.
+5. Return `connected` after a successful refresh.
+6. Return `disconnected` after unauthorized refresh and existing cleanup.
+7. Return `unknown` for broker or network refresh failures that do not prove disconnection.
+
+Relevant files:
+
+- `src/tui/dialog.tsx`
+- `src/server/tools.ts`
+- `src/server/store.ts`
+
+## Disconnect Behavior
+
+Choosing `Disconnect` from either `already_connected` or `unknown_auth` should clear the locally saved auth through the existing server-side clear path, then return the user to the disconnected connect state.
+
+Disconnect does not revoke Supabase credentials remotely. It only forgets the local saved auth used by the plugin.
+
+## Error Handling and Accepted Limitations
+
+The preflight must reuse the existing store path resolution so worktree and session scoping remain correct.
+
+Unauthorized refresh should be treated as `disconnected`, not `unknown`.
+
+Broker or network failures during refresh should be treated as `unknown`, not `disconnected`.
+
+A fresh-but-remotely-revoked access token may still appear connected until the next real API call or the next refresh window. This is an accepted limitation for this iteration.
+
+Host auth and local saved auth can still drift because host sync and cleanup are best-effort today. This design does not change that behavior.
+
+## Testing Expectations
+
+Add automated coverage for these cases:
+
+- `/supabase` shows the current connect dialog when no saved auth exists
+- `/supabase` shows `Already connected` when saved auth is still fresh
+- `/supabase` shows `Checking Supabase connection...` while a refresh is in flight
+- `/supabase` shows `Already connected` after a successful refresh
+- `/supabase` shows the connect dialog after unauthorized refresh clears auth
+- `/supabase` shows the unknown-state dialog after broker or network refresh failure
+- `Disconnect` clears saved auth and returns the dialog to the disconnected flow
+- store path resolution still targets the correct `.opencode/supabase-auth.json` location
+
+## Rationale
+
+This design uses the same definition of usable auth that tool execution already trusts. That keeps the `/supabase` UI aligned with actual runtime behavior instead of inventing a second auth policy inside the TUI.
+
+Not forcing refresh on every `/supabase` open avoids unnecessary latency, extra broker dependence, ambiguous offline failures, and token churn when the current access token is already good enough.

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -12,7 +12,8 @@ import type { SupabaseLogger } from "../shared/log.ts";
 import { buildAuthorizeUrl, generatePKCE, generateState } from "../shared/oauth.ts";
 import type { FetchLike, SupabaseTokenResponse } from "../shared/types.ts";
 import { HTML_SUCCESS, htmlError } from "./auth-html.ts";
-import { writeSavedAuth } from "./store.ts";
+import { readSavedAuth, writeSavedAuth } from "./store.ts";
+import { NOT_CONNECTED_MESSAGE, disconnectSupabaseAuth, ensureSupabaseToolAuth } from "./tools.ts";
 
 const CALLBACK_PATH = "/auth/callback";
 const CALLBACK_TIMEOUT_MS = 5 * 60 * 1000;
@@ -33,9 +34,47 @@ type AuthDeps = {
   setCallbackTimeout?: typeof setTimeout;
 };
 
+type SupabaseAuthInput = Pick<PluginInput, "client" | "directory" | "serverUrl" | "worktree">;
+
+type SupabaseStatusInstructions =
+  | {
+      status: "connected";
+      checked: false;
+    }
+  | {
+      status: "disconnected";
+      checked: false;
+    }
+  | {
+      status: "refresh_required";
+      checked: true;
+    };
+
 let server: ReturnType<typeof Bun.serve> | undefined;
 let serverPort: number | undefined;
 const pendingAuths = new Map<string, PendingAuth>();
+const REFRESH_BUFFER_MS = 30_000;
+
+function isRefreshNeeded(expires: number) {
+  return expires <= Date.now() + REFRESH_BUFFER_MS;
+}
+
+function encodeStatusInstructions(status: SupabaseStatusInstructions) {
+  return JSON.stringify(status);
+}
+
+async function getStatusInstructions(input: Pick<SupabaseAuthInput, "directory" | "worktree">) {
+  const saved = await readSavedAuth(input);
+  if (!saved.auth) {
+    return encodeStatusInstructions({ status: "disconnected", checked: false });
+  }
+
+  if (!isRefreshNeeded(saved.auth.expires)) {
+    return encodeStatusInstructions({ status: "connected", checked: false });
+  }
+
+  return encodeStatusInstructions({ status: "refresh_required", checked: true });
+}
 
 function callbackUrl(port: number) {
   return `http://localhost:${port}${CALLBACK_PATH}`;
@@ -268,7 +307,7 @@ function waitForCallback(
 }
 
 export function createSupabaseAuth(
-  input: Pick<PluginInput, "directory" | "worktree">,
+  input: SupabaseAuthInput,
   options?: PluginOptions,
   deps: AuthDeps = {},
 ) {
@@ -303,6 +342,56 @@ export function createSupabaseAuth(
                 refresh: tokens.refresh_token,
                 expires,
               };
+            },
+          };
+        },
+      },
+      {
+        type: "oauth" as const,
+        label: "Supabase Status",
+        async authorize(inputs?: Record<string, string>) {
+          if (inputs?.action === "disconnect") {
+            await disconnectSupabaseAuth(input, { fetch: deps.fetch });
+            return {
+              url: "https://supabase.com/",
+              instructions: encodeStatusInstructions({ status: "disconnected", checked: false }),
+              method: "auto" as const,
+              callback: async () => ({ type: "failed" as const }),
+            };
+          }
+
+          const instructions = await getStatusInstructions(input);
+          const status = JSON.parse(instructions) as SupabaseStatusInstructions;
+
+          if (status.status !== "refresh_required") {
+            return {
+              url: "https://supabase.com/",
+              instructions,
+              method: "auto" as const,
+              callback: async () => ({ type: "failed" as const }),
+            };
+          }
+
+          return {
+            url: "https://supabase.com/",
+            instructions,
+            method: "auto" as const,
+            callback: async () => {
+              try {
+                const auth = await ensureSupabaseToolAuth(input, options, deps);
+                return {
+                  type: "success" as const,
+                  access: auth.access,
+                  refresh: auth.refresh,
+                  expires: auth.expires,
+                };
+              } catch (error) {
+                const message = error instanceof Error ? error.message : String(error);
+                if (message === NOT_CONNECTED_MESSAGE) {
+                  return { type: "failed" as const };
+                }
+                throw error;
+              }
             },
           };
         },

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -44,7 +44,23 @@ type SupabaseToolContext = Pick<
   "directory" | "worktree" | "abort" | "sessionID" | "messageID" | "agent" | "metadata" | "ask"
 >;
 
-const NOT_CONNECTED_MESSAGE = "Supabase is not connected. Run /supabase first.";
+export type SupabaseAuthStatus =
+  | {
+      status: "connected";
+      auth: SavedAuth;
+      checked: boolean;
+    }
+  | {
+      status: "disconnected";
+      checked: boolean;
+    }
+  | {
+      status: "unknown";
+      checked: true;
+      message: string;
+    };
+
+export const NOT_CONNECTED_MESSAGE = "Supabase is not connected. Run /supabase first.";
 const REFRESH_BUFFER_MS = 30_000;
 
 function isRefreshNeeded(auth: SavedAuth) {
@@ -166,6 +182,44 @@ async function clearHostAuth(
   const response = await fetchImpl(url.toString(), { method: "DELETE" });
   if (!response.ok) {
     throw new Error(`Failed to clear host auth: ${response.status}`);
+  }
+}
+
+export async function disconnectSupabaseAuth(
+  input: SupabaseToolInput,
+  deps: Pick<ToolDeps, "fetch"> = {},
+) {
+  const fetchImpl = deps.fetch ?? fetch;
+  await clearSavedAuth(input);
+  try {
+    await clearHostAuth(input, fetchImpl);
+  } catch {}
+}
+
+export async function getSupabaseAuthStatus(
+  input: SupabaseToolInput,
+  options?: PluginOptions,
+  deps: ToolDeps = {},
+): Promise<SupabaseAuthStatus> {
+  const saved = await readSavedAuth(input);
+  if (!saved.auth) {
+    return { status: "disconnected", checked: false };
+  }
+
+  if (!isRefreshNeeded(saved.auth)) {
+    return { status: "connected", auth: saved.auth, checked: false };
+  }
+
+  try {
+    const auth = await ensureSupabaseToolAuth(input, options, deps);
+    return { status: "connected", auth, checked: true };
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === NOT_CONNECTED_MESSAGE) {
+      return { status: "disconnected", checked: true };
+    }
+
+    return { status: "unknown", checked: true, message };
   }
 }
 

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -10,11 +10,17 @@ import {
 import { readSupabaseConfig } from "../shared/cfg.ts";
 import type { SupabaseLogger } from "../shared/log.ts";
 import type { FetchLike } from "../shared/types.ts";
-import { type SavedAuth, clearSavedAuth, readSavedAuth, writeSavedAuth } from "./store.ts";
+import { type SavedAuth, clearSavedAuth, getStoreFile, readSavedAuth, writeSavedAuth } from "./store.ts";
 
 type ToolDeps = {
   fetch?: FetchLike;
   logger?: SupabaseLogger;
+};
+
+type InFlightRefresh = {
+  promise: Promise<SavedAuth>;
+  syncedDirectories: Set<string>;
+  syncPromises: Map<string, Promise<void>>;
 };
 
 type HostAuthWriter = {
@@ -62,9 +68,15 @@ export type SupabaseAuthStatus =
 
 export const NOT_CONNECTED_MESSAGE = "Supabase is not connected. Run /supabase first.";
 const REFRESH_BUFFER_MS = 30_000;
+const inFlightRefreshes = new Map<string, InFlightRefresh>();
 
 function isRefreshNeeded(auth: SavedAuth) {
   return auth.expires <= Date.now() + REFRESH_BUFFER_MS;
+}
+
+function isSameAuth(left: SavedAuth | undefined, right: SavedAuth | undefined) {
+  if (!left || !right) return left === right;
+  return left.access === right.access && left.refresh === right.refresh && left.expires === right.expires;
 }
 
 function generateRandomString(length: number) {
@@ -185,12 +197,35 @@ async function clearHostAuth(
   }
 }
 
+async function syncHostAuthForDirectory(entry: InFlightRefresh, input: SupabaseToolInput, auth: SavedAuth) {
+  if (entry.syncedDirectories.has(input.directory)) {
+    return;
+  }
+
+  const existing = entry.syncPromises.get(input.directory);
+  if (existing) {
+    await existing.catch(() => undefined);
+    return;
+  }
+
+  const syncPromise = (async () => {
+    await setHostAuth(input, auth);
+    entry.syncedDirectories.add(input.directory);
+  })().finally(() => {
+    entry.syncPromises.delete(input.directory);
+  });
+
+  entry.syncPromises.set(input.directory, syncPromise);
+  await syncPromise.catch(() => undefined);
+}
+
 export async function disconnectSupabaseAuth(
   input: SupabaseToolInput,
   deps: Pick<ToolDeps, "fetch"> = {},
 ) {
   const fetchImpl = deps.fetch ?? fetch;
   await clearSavedAuth(input);
+  inFlightRefreshes.delete(getStoreFile(input));
   try {
     await clearHostAuth(input, fetchImpl);
   } catch {}
@@ -228,50 +263,115 @@ export async function ensureSupabaseToolAuth(
   options?: PluginOptions,
   deps: ToolDeps = {},
 ): Promise<SavedAuth> {
-  const fetchImpl = deps.fetch ?? fetch;
+  const refreshKey = getStoreFile(input);
   const saved = await readSavedAuth(input);
   if (!saved.auth) {
     throw new Error(NOT_CONNECTED_MESSAGE);
   }
 
+  const inFlight = inFlightRefreshes.get(refreshKey);
+  if (inFlight) {
+    const fetchImpl = deps.fetch ?? fetch;
+    try {
+      const auth = await inFlight.promise;
+      await syncHostAuthForDirectory(inFlight, input, auth);
+      return auth;
+    } catch (error) {
+      if ((error instanceof Error ? error.message : String(error)) === NOT_CONNECTED_MESSAGE) {
+        try {
+          await clearHostAuth(input, fetchImpl);
+        } catch {}
+      }
+      throw error;
+    }
+  }
+
   if (!isRefreshNeeded(saved.auth)) {
+    try {
+      await setHostAuth(input, saved.auth);
+    } catch {}
     return saved.auth;
   }
 
-  const config = readSupabaseConfig(options);
-
-  try {
-    const refreshed = await refreshTokenThroughBroker(
-      { baseUrl: config.brokerBaseUrl },
-      { refresh_token: saved.auth.refresh },
-      deps.fetch,
-      deps.logger,
-    );
-
-    const nextAuth: SavedAuth = {
-      access: refreshed.access_token,
-      refresh: refreshed.refresh_token,
-      expires: Date.now() + (refreshed.expires_in ?? 3600) * 1000,
-    };
-    await writeSavedAuth(input, nextAuth);
-    try {
-      await setHostAuth(input, nextAuth);
-    } catch {}
-    return nextAuth;
-  } catch (error) {
-    if (error instanceof BrokerClientError && (error.status === 401 || error.status === 400)) {
-      await clearSavedAuth(input);
-      try {
-        await clearHostAuth(input, fetchImpl);
-      } catch {}
+  const refreshEntry: InFlightRefresh = {
+    promise: Promise.resolve({ access: "", refresh: "", expires: 0 }),
+    syncedDirectories: new Set<string>(),
+    syncPromises: new Map<string, Promise<void>>(),
+  };
+  const refreshPromise = (async () => {
+    const fetchImpl = deps.fetch ?? fetch;
+    const current = await readSavedAuth(input);
+    if (!current.auth) {
       throw new Error(NOT_CONNECTED_MESSAGE);
     }
 
-    if (error instanceof BrokerClientError) {
-      throw new Error(`Supabase auth refresh failed: ${error.message}`);
+    if (!isRefreshNeeded(current.auth)) {
+      return current.auth;
     }
-    throw error;
-  }
+
+    const config = readSupabaseConfig(options);
+
+    try {
+      const refreshed = await refreshTokenThroughBroker(
+        { baseUrl: config.brokerBaseUrl },
+        { refresh_token: current.auth.refresh },
+        deps.fetch,
+        deps.logger,
+      );
+
+      const nextAuth: SavedAuth = {
+        access: refreshed.access_token,
+        refresh: refreshed.refresh_token,
+        expires: Date.now() + (refreshed.expires_in ?? 3600) * 1000,
+      };
+
+      const latest = await readSavedAuth(input);
+      if (!latest.auth) {
+        throw new Error(NOT_CONNECTED_MESSAGE);
+      }
+
+      if (!isSameAuth(latest.auth, current.auth)) {
+        return latest.auth;
+      }
+
+      await writeSavedAuth(input, nextAuth);
+      return nextAuth;
+    } catch (error) {
+      if (error instanceof BrokerClientError && (error.status === 401 || error.status === 400)) {
+        const latest = await readSavedAuth(input);
+        if (!isSameAuth(latest.auth, current.auth)) {
+          if (latest.auth) {
+            return latest.auth;
+          }
+          throw new Error(NOT_CONNECTED_MESSAGE);
+        }
+
+        await clearSavedAuth(input);
+        try {
+          await clearHostAuth(input, fetchImpl);
+        } catch {}
+        throw new Error(NOT_CONNECTED_MESSAGE);
+      }
+
+      if (error instanceof BrokerClientError) {
+        throw new Error(`Supabase auth refresh failed: ${error.message}`);
+      }
+      throw error;
+    }
+  })();
+  refreshEntry.promise = refreshPromise
+    .then(async (auth) => {
+      await syncHostAuthForDirectory(refreshEntry, input, auth);
+      return auth;
+    })
+    .finally(() => {
+      if (inFlightRefreshes.get(refreshKey)?.promise === refreshEntry.promise) {
+      inFlightRefreshes.delete(refreshKey);
+      }
+    });
+
+  inFlightRefreshes.set(refreshKey, refreshEntry);
+  return refreshEntry.promise;
 }
 
 export function createSupabaseTools(

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -361,10 +361,11 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
   if (currentState.type === "already_connected") {
     return props.api.ui.DialogConfirm({
       title: "Already connected to Supabase",
-      message: "Your saved Supabase login is ready to use. Continue to close this dialog, or cancel to disconnect.",
+      message: "Your saved Supabase login is ready to use. Continue to close this dialog, or disconnect to sign out.",
       onConfirm: closeDialog,
       onCancel: disconnect,
-    });
+      label: "Disconnect",
+    } as import("./opencode-runtime-extensions.ts").DialogConfirmWithLabel);
   }
 
   if (currentState.type === "unknown") {

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -12,6 +12,7 @@ type SupabaseDialogProps = {
   lifecycle?: {
     closed: boolean;
     dismissed?: boolean;
+    preflightPromise?: Promise<void>;
   };
 };
 
@@ -258,12 +259,21 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       },
     });
 
-  const retryPreflight = () =>
-    runAuthPreflight({
+  const retryPreflight = () => {
+    if (lifecycle.preflightPromise) {
+      return lifecycle.preflightPromise;
+    }
+
+    lifecycle.preflightPromise = runAuthPreflight({
       api: props.api,
       logger: props.logger,
       setState,
+    }).finally(() => {
+      lifecycle.preflightPromise = undefined;
     });
+
+    return lifecycle.preflightPromise;
+  };
 
   const disconnect = async () => {
     try {
@@ -272,19 +282,23 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
         method: 1,
         inputs: { action: "disconnect" },
       });
+      closeDialog();
     } catch (error) {
       await props.logger.warn("supabase disconnect failed", {
         message: getErrorMessage(error),
       });
+      setState({
+        type: "unknown",
+        message: `Couldn't disconnect from Supabase right now. ${formatAuthError("unknown", error)}`,
+      });
     }
-    closeDialog();
   };
 
   const currentState = state();
 
   if (currentState.type === "checking_auth") {
     queueMicrotask(() => {
-      if (lifecycle.closed) {
+      if (lifecycle.closed || lifecycle.preflightPromise) {
         return;
       }
       void retryPreflight();

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -16,10 +16,13 @@ type SupabaseDialogProps = {
 };
 
 type OAuthState =
+  | { type: "checking_auth" }
   | { type: "idle" }
+  | { type: "already_connected" }
   | { type: "authorizing"; url: string }
   | { type: "waiting_callback"; url: string }
   | { type: "success" }
+  | { type: "unknown"; message: string }
   | { type: "error"; message: string; url?: string };
 
 type ApiResponse<T> = { data?: T; error?: unknown };
@@ -30,6 +33,11 @@ type AuthData = {
   method: string;
 };
 
+type AuthStatus =
+  | { status: "connected"; checked: boolean }
+  | { status: "disconnected"; checked: boolean }
+  | { status: "refresh_required"; checked: true };
+
 type AuthFlowContext = {
   api: TuiPluginApi;
   logger: SupabaseLogger;
@@ -39,6 +47,19 @@ type AuthFlowContext = {
 
 function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+function parseAuthStatus(instructions: string): AuthStatus {
+  const parsed = JSON.parse(instructions) as Partial<AuthStatus>;
+  if (
+    parsed.status === "connected" ||
+    parsed.status === "disconnected" ||
+    parsed.status === "refresh_required"
+  ) {
+    return parsed as AuthStatus;
+  }
+
+  throw new Error("Invalid Supabase auth status response");
 }
 
 async function openBrowser(url: string, logger: SupabaseLogger) {
@@ -132,9 +153,61 @@ export async function runAuthFlow(context: AuthFlowContext) {
   }
 }
 
+export async function runAuthPreflight(context: Pick<AuthFlowContext, "api" | "logger" | "setState">) {
+  context.setState({ type: "checking_auth" });
+
+  try {
+    const authResponse = (await context.api.client.provider.oauth.authorize({
+      providerID: "supabase",
+      method: 1,
+    })) as ApiResponse<AuthData>;
+
+    if (authResponse.error) {
+      throw new Error(formatAuthError("start", authResponse.error));
+    }
+
+    const instructions = authResponse.data?.instructions;
+    if (!instructions) {
+      throw new Error("Invalid Supabase auth status response");
+    }
+
+    const status = parseAuthStatus(instructions);
+    if (status.status === "connected") {
+      context.setState({ type: "already_connected" });
+      return;
+    }
+
+    if (status.status === "disconnected") {
+      context.setState({ type: "idle" });
+      return;
+    }
+
+    const callbackResponse = (await context.api.client.provider.oauth.callback({
+      providerID: "supabase",
+      method: 1,
+    })) as ApiResponse<boolean>;
+
+    if (callbackResponse.error) {
+      throw new Error(formatAuthError("callback", callbackResponse.error));
+    }
+
+    if (callbackResponse.data === true) {
+      context.setState({ type: "already_connected" });
+      return;
+    }
+
+    context.setState({ type: "idle" });
+  } catch (error) {
+    context.setState({
+      type: "unknown",
+      message: formatAuthError("unknown", error),
+    });
+  }
+}
+
 export function SupabaseDialog(props: SupabaseDialogProps) {
   const lifecycle = props.lifecycle ?? { closed: false };
-  const [state, setStateSignal] = createSignal<OAuthState>(props.initialState ?? { type: "idle" });
+  const [state, setStateSignal] = createSignal<OAuthState>(props.initialState ?? { type: "checking_auth" });
 
   const closeDialog = (dismissed = false) => {
     lifecycle.closed = true;
@@ -185,7 +258,44 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       },
     });
 
+  const retryPreflight = () =>
+    runAuthPreflight({
+      api: props.api,
+      logger: props.logger,
+      setState,
+    });
+
+  const disconnect = async () => {
+    try {
+      await props.api.client.provider.oauth.authorize({
+        providerID: "supabase",
+        method: 1,
+        inputs: { action: "disconnect" },
+      });
+    } catch (error) {
+      await props.logger.warn("supabase disconnect failed", {
+        message: getErrorMessage(error),
+      });
+    }
+    closeDialog();
+  };
+
   const currentState = state();
+
+  if (currentState.type === "checking_auth") {
+    queueMicrotask(() => {
+      if (lifecycle.closed) {
+        return;
+      }
+      void retryPreflight();
+    });
+
+    return props.api.ui.DialogAlert({
+      title: "Connect Supabase",
+      message: "Checking Supabase connection...",
+      onConfirm: () => closeDialog(true),
+    });
+  }
 
   if (currentState.type === "idle") {
     return props.api.ui.DialogConfirm({
@@ -230,6 +340,24 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       onConfirm: async () => {
         await startOAuth();
       },
+      onCancel: closeDialog,
+    });
+  }
+
+  if (currentState.type === "already_connected") {
+    return props.api.ui.DialogConfirm({
+      title: "Already connected to Supabase",
+      message: "Your saved Supabase login is ready to use. Continue to close this dialog, or cancel to disconnect.",
+      onConfirm: closeDialog,
+      onCancel: disconnect,
+    });
+  }
+
+  if (currentState.type === "unknown") {
+    return props.api.ui.DialogConfirm({
+      title: "Supabase connection status unknown",
+      message: `${currentState.message}\n\nConfirm to retry, or cancel to continue without changing saved auth.`,
+      onConfirm: retryPreflight,
       onCancel: closeDialog,
     });
   }

--- a/src/tui/index.tsx
+++ b/src/tui/index.tsx
@@ -11,7 +11,15 @@ const tui: TuiPlugin = async (api) => {
 
   api.command.register(() => [
     createSupabaseCommand(() => {
-      api.ui.dialog.replace(() => SupabaseDialog({ api, logger, onClose: () => api.ui.dialog.clear() }));
+      const lifecycle = { closed: false };
+      api.ui.dialog.replace(() =>
+        SupabaseDialog({
+          api,
+          logger,
+          lifecycle,
+          onClose: () => api.ui.dialog.clear(),
+        }),
+      );
     }),
   ]);
 };

--- a/src/tui/opencode-runtime-extensions.ts
+++ b/src/tui/opencode-runtime-extensions.ts
@@ -1,0 +1,10 @@
+// OpenCode host supports `label` on DialogConfirm since ~Mar 2026
+// (commit e2d03ce38 in opencode repo: interactive update flow for non-patch releases).
+// The @opencode-ai/plugin SDK types (up to 1.14.24) never declared it.
+// This module patches the gap locally until the SDK catches up.
+
+import type { TuiDialogConfirmProps } from "@opencode-ai/plugin/tui";
+
+export type DialogConfirmWithLabel = TuiDialogConfirmProps & {
+  label?: string;
+};

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -453,6 +453,127 @@ test("supabase dialog already connected offers disconnect action", async () => {
   expect(api.__test.cleared).toBe(1);
 });
 
+test("supabase dialog starts preflight only once while first check is pending", async () => {
+  let authorizeCalls = 0;
+  let currentDialog: unknown;
+
+  const api = createDialogApi({
+    ui: {
+      Dialog: (input: unknown) => input,
+      DialogAlert: (input: unknown) => input,
+      DialogConfirm: (input: unknown) => input,
+      toast: (_input: { variant?: string; message: string }) => undefined,
+      dialog: {
+        replace: (factory: () => unknown) => {
+          currentDialog = factory();
+        },
+        clear: () => undefined,
+      },
+    },
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method?: number }) => {
+            if (method === 1) {
+              authorizeCalls += 1;
+              if (authorizeCalls > 1) {
+                return Promise.reject(new Error("duplicate preflight"));
+              }
+              return Promise.resolve({
+                data: {
+                  url: "https://supabase.com/",
+                  instructions: JSON.stringify({ status: "connected", checked: false }),
+                  method: "code",
+                },
+              });
+            }
+            return Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } });
+          },
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  });
+
+  currentDialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => undefined,
+  });
+
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(currentDialog).toMatchObject({
+    title: "Already connected to Supabase",
+  });
+  expect(authorizeCalls).toBe(1);
+});
+
+test("supabase dialog keeps disconnect failure visible", async () => {
+  let currentDialog: unknown;
+  const api = createDialogApi({
+    ui: {
+      Dialog: (input: unknown) => input,
+      DialogAlert: (input: unknown) => input,
+      DialogConfirm: (input: unknown) => input,
+      toast: (_input: { variant?: string; message: string }) => undefined,
+      dialog: {
+        replace: (factory: () => unknown) => {
+          currentDialog = factory();
+        },
+        clear: () => undefined,
+      },
+    },
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: () => Promise.reject(new Error("disconnect unavailable")),
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  });
+
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "already_connected" },
+  }) as { onCancel?: () => Promise<void> };
+  currentDialog = dialog;
+
+  await dialog.onCancel?.();
+
+  expect(api.__test.cleared).toBe(0);
+  expect(currentDialog).toMatchObject({
+    title: "Supabase connection status unknown",
+  });
+});
+
 test("supabase dialog unknown state offers retry and continue", async () => {
   const api = createDialogApi();
   const dialog = SupabaseDialog({

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -3,7 +3,7 @@ import { expect, test } from "bun:test";
 import { HTML_SUCCESS } from "../src/server/auth-html.ts";
 import serverModule from "../src/server/index.ts";
 import { createSupabaseCommand } from "../src/tui/commands.ts";
-import { SupabaseDialog, runAuthFlow } from "../src/tui/dialog.tsx";
+import { SupabaseDialog, runAuthFlow, runAuthPreflight } from "../src/tui/dialog.tsx";
 import tuiModule from "../src/tui/index.tsx";
 
 type LogEntry = Record<string, unknown>;
@@ -292,12 +292,206 @@ test("supabase dialog success shows example prompts and inserts on confirm", asy
   expect(states.at(-1)).toEqual({ type: "success" });
 });
 
+test("supabase auth preflight reports already connected when saved auth is still valid", async () => {
+  const states: Array<Record<string, unknown>> = [];
+  const api = createDialogApi({
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method?: number }) => {
+            if (method === 1) {
+              return Promise.resolve({
+                data: {
+                  url: "https://supabase.com/",
+                  instructions: JSON.stringify({ status: "connected", checked: false }),
+                  method: "code",
+                },
+              });
+            }
+            return Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } });
+          },
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  });
+
+  await runAuthPreflight({
+    api: api as never,
+    logger: createLogger(),
+    setState: (state) => {
+      states.push(state as unknown as Record<string, unknown>);
+    },
+  });
+
+  expect(states).toEqual([{ type: "checking_auth" }, { type: "already_connected" }]);
+});
+
+test("supabase auth preflight shows unknown state when refresh verification fails", async () => {
+  const states: Array<Record<string, unknown>> = [];
+  const api = createDialogApi({
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method?: number }) => {
+            if (method === 1) {
+              return Promise.resolve({
+                data: {
+                  url: "https://supabase.com/",
+                  instructions: JSON.stringify({ status: "refresh_required", checked: true }),
+                  method: "auto",
+                },
+              });
+            }
+            return Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } });
+          },
+          callback: ({ method }: { method?: number }) => {
+            if (method === 1) {
+              return Promise.resolve({
+                error: {
+                  data: {
+                    name: "UnknownError",
+                    data: {
+                      message: "Supabase auth refresh failed: broker unavailable",
+                    },
+                  },
+                  errors: [],
+                  success: false,
+                },
+              });
+            }
+            return Promise.resolve({ data: true });
+          },
+        },
+      },
+    },
+  });
+
+  await runAuthPreflight({
+    api: api as never,
+    logger: createLogger(),
+    setState: (state) => {
+      states.push(state as unknown as Record<string, unknown>);
+    },
+  });
+
+  expect(states).toEqual([
+    { type: "checking_auth" },
+    {
+      type: "unknown",
+      message: "Supabase auth refresh failed: broker unavailable",
+    },
+  ]);
+});
+
+test("supabase dialog already connected offers disconnect action", async () => {
+  const authorizeCalls: Array<{ providerID?: string; method?: number; inputs?: Record<string, string> }> = [];
+  const api = createDialogApi({
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: (input: { method?: number; inputs?: Record<string, string> }) => {
+            authorizeCalls.push(input);
+            return Promise.resolve({
+              data: {
+                url: "https://supabase.com/",
+                instructions: JSON.stringify({ status: "disconnected", checked: false }),
+                method: "code",
+              },
+            });
+          },
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  });
+
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "already_connected" },
+  }) as { title?: string; message?: string; onCancel?: () => Promise<void> };
+
+  expect(dialog.title).toBe("Already connected to Supabase");
+  await dialog.onCancel?.();
+
+  expect(authorizeCalls).toEqual([{ providerID: "supabase", method: 1, inputs: { action: "disconnect" } }]);
+  expect(api.__test.cleared).toBe(1);
+});
+
+test("supabase dialog unknown state offers retry and continue", async () => {
+  const api = createDialogApi();
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: {
+      type: "unknown",
+      message: "Saved Supabase login found, but couldn't verify it right now.",
+    },
+  }) as { title?: string; onConfirm?: () => Promise<void>; onCancel?: () => void };
+
+  expect(dialog.title).toBe("Supabase connection status unknown");
+  expect(typeof dialog.onConfirm).toBe("function");
+  expect(typeof dialog.onCancel).toBe("function");
+});
+
+test("supabase dialog starts with built in checking alert", () => {
+  const api = createDialogApi();
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+  });
+
+  expect(dialog).toMatchObject({
+    title: "Connect Supabase",
+  });
+  expect(api.__test.dialogAlerts).toHaveLength(1);
+  expect(api.__test.dialogs).toHaveLength(0);
+});
+
 test("supabase dialog idle uses built in confirm dialog", () => {
   const api = createDialogApi();
   const dialog = SupabaseDialog({
     api: api as never,
     logger: createLogger(),
     onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "idle" },
   });
 
   expect(dialog).toMatchObject({

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -522,6 +522,96 @@ test("supabase dialog starts preflight only once while first check is pending", 
   expect(authorizeCalls).toBe(1);
 });
 
+test("tui plugin reusing the original /supabase dialog factory should not start duplicate preflight work", async () => {
+  let commandsFactory: (() => Array<Record<string, unknown>>) | undefined;
+  let replaceFactory: (() => unknown) | undefined;
+  let authorizeCalls = 0;
+  let resolveFirstAuthorize: (() => void) | undefined;
+
+  await tuiModule.tui(
+    {
+      command: {
+        register: (factory: () => Array<Record<string, unknown>>) => {
+          commandsFactory = factory;
+          return () => {};
+        },
+      },
+      ui: {
+        Dialog: (input: unknown) => input,
+        DialogAlert: (input: unknown) => input,
+        DialogConfirm: (input: unknown) => input,
+        dialog: {
+          replace: (factory: () => unknown) => {
+            replaceFactory = factory;
+          },
+          clear: () => {},
+        },
+        toast: () => {},
+      },
+      client: {
+        provider: {
+          oauth: {
+            authorize: ({ method }: { method?: number }) => {
+              if (method === 1) {
+                authorizeCalls += 1;
+                if (authorizeCalls === 1) {
+                  return new Promise((resolve) => {
+                    resolveFirstAuthorize = () =>
+                      resolve({
+                        data: {
+                          url: "https://supabase.com/",
+                          instructions: JSON.stringify({ status: "connected", checked: false }),
+                          method: "code",
+                        },
+                      });
+                  });
+                }
+
+                return Promise.resolve({
+                  data: {
+                    url: "https://supabase.com/",
+                    instructions: JSON.stringify({ status: "connected", checked: false }),
+                    method: "code",
+                  },
+                });
+              }
+
+              return Promise.resolve({
+                data: {
+                  url: "https://example.com/auth",
+                  instructions: "Test",
+                  method: "manual",
+                },
+              });
+            },
+            callback: () => Promise.resolve({ data: true }),
+          },
+        },
+      },
+    } as never,
+    undefined,
+    {} as never,
+  );
+
+  const command = commandsFactory?.()[0] as { onSelect?: () => void } | undefined;
+  command?.onSelect?.();
+
+  expect(typeof replaceFactory).toBe("function");
+  replaceFactory?.();
+  replaceFactory?.();
+
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(authorizeCalls).toBe(1);
+
+  resolveFirstAuthorize?.();
+  await Promise.resolve();
+  await Promise.resolve();
+
+  expect(authorizeCalls).toBe(1);
+});
+
 test("supabase dialog keeps disconnect failure visible", async () => {
   let currentDialog: unknown;
   const api = createDialogApi({

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { createSupabaseAuth, stopSupabaseAuthServer } from "../src/server/auth.ts";
-import { readSavedAuth } from "../src/server/store.ts";
+import { readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
 import { createSupabaseLogger } from "../src/shared/log.ts";
 import type { FetchLike } from "../src/shared/types.ts";
 
@@ -16,7 +16,13 @@ async function createInput() {
   const root = await mkdtemp(join(tmpdir(), "opencode-supabase-auth-"));
   cleanupPaths.push(root);
   return {
+    client: {
+      auth: {
+        set: mock(async () => true),
+      },
+    },
     directory: join(root, "consumer"),
+    serverUrl: new URL("http://127.0.0.1:7777/"),
     worktree: root,
   };
 }
@@ -24,6 +30,12 @@ async function createInput() {
 function firstAuthMethod(auth: ReturnType<typeof createSupabaseAuth>) {
   const method = auth.methods[0];
   if (!method) throw new Error("Expected an auth method");
+  return method;
+}
+
+function secondAuthMethod(auth: ReturnType<typeof createSupabaseAuth>) {
+  const method = auth.methods[1];
+  if (!method) throw new Error("Expected a status auth method");
   return method;
 }
 
@@ -58,6 +70,102 @@ afterEach(async () => {
 });
 
 describe("server auth hook", () => {
+  test("exposes status method alongside connect oauth", async () => {
+    const input = await createInput();
+
+    const auth = createSupabaseAuth(input as never);
+
+    expect(auth.methods).toHaveLength(2);
+    expect(auth.methods[0]).toMatchObject({ type: "oauth", label: "Supabase" });
+    expect(auth.methods[1]).toMatchObject({ type: "oauth", label: "Supabase Status" });
+  });
+
+  test("status method reports disconnected when no saved auth exists", async () => {
+    const input = await createInput();
+
+    const auth = createSupabaseAuth(input as never);
+    const result = await secondAuthMethod(auth).authorize();
+
+    expect(JSON.parse(result.instructions)).toEqual({
+      status: "disconnected",
+      checked: false,
+    });
+  });
+
+  test("status method reports refresh_required when saved auth is stale", async () => {
+    const input = await createInput();
+    await writeSavedAuth(input as never, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    const auth = createSupabaseAuth(input as never);
+    const result = await secondAuthMethod(auth).authorize();
+
+    expect(JSON.parse(result.instructions)).toEqual({
+      status: "refresh_required",
+      checked: true,
+    });
+  });
+
+  test("status method disconnect action clears saved auth", async () => {
+    const input = await createInput();
+    await writeSavedAuth(input as never, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const auth = createSupabaseAuth(input as never);
+    const result = await secondAuthMethod(auth).authorize({ action: "disconnect" });
+
+    expect(JSON.parse(result.instructions)).toEqual({
+      status: "disconnected",
+      checked: false,
+    });
+    expect(await readSavedAuth(input as never)).toEqual({ version: 1 });
+  });
+
+  test("status method refresh callback reports failed when refresh token is invalid", async () => {
+    const input = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input as never, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    const auth = createSupabaseAuth(
+      input as never,
+      undefined,
+      {
+        fetch: mock(async () =>
+          new Response(
+            JSON.stringify({
+              error: {
+                code: "invalid_grant",
+                message: "Refresh token expired",
+              },
+            }),
+            {
+              status: 401,
+              headers: { "Content-Type": "application/json" },
+            },
+          ),
+        ) as never,
+      },
+    );
+
+    const result = await secondAuthMethod(auth).authorize();
+
+    expect(JSON.parse(result.instructions)).toEqual({
+      status: "refresh_required",
+      checked: true,
+    });
+    await expect(result.callback?.()).resolves.toEqual({ type: "failed" });
+  });
+
   test("logs auth authorize and callback completion without secrets", async () => {
     const input = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
@@ -459,6 +567,9 @@ describe("server auth hook", () => {
       access: "access-123",
       refresh: "refresh-123",
     });
+    if (callbackResult.type !== "success") {
+      throw new Error("Expected OAuth callback to succeed");
+    }
     expect(typeof callbackResult.expires).toBe("number");
     expect(callbackResult.expires).toBeGreaterThan(Date.now());
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -555,6 +666,9 @@ describe("server auth hook", () => {
       access: "access-123",
       refresh: "refresh-123",
     });
+    if (callbackResult.type !== "success") {
+      throw new Error("Expected OAuth callback to succeed");
+    }
     expect(typeof callbackResult.expires).toBe("number");
     expect(fetchMock).toHaveBeenCalledTimes(1);
     await expect(readSavedAuth({ ...input, worktree: "/" } as never)).resolves.toEqual({
@@ -606,6 +720,9 @@ describe("server auth hook", () => {
       access: "access-123",
       refresh: "refresh-123",
     });
+    if (callbackResult.type !== "success") {
+      throw new Error("Expected OAuth callback to succeed");
+    }
     expect(typeof callbackResult.expires).toBe("number");
     await expect(readSavedAuth({ ...input, worktree: "" } as never)).resolves.toEqual({
       version: 1,

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -8,7 +8,9 @@ import { readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
 import {
   type SupabaseToolInput,
   createSupabaseTools,
+  disconnectSupabaseAuth,
   ensureSupabaseToolAuth,
+  getSupabaseAuthStatus,
 } from "../src/server/tools.ts";
 import { createSupabaseLogger } from "../src/shared/log.ts";
 import type { FetchLike } from "../src/shared/types.ts";
@@ -230,6 +232,92 @@ describe("server tools auth helper", () => {
     await tools.supabase_list_projects.execute({}, createContext(input));
 
     expect(hostAuthSet).toHaveBeenCalledTimes(1);
+  });
+
+  test("reports connected when saved auth is still fresh", async () => {
+    const { input } = await createInput();
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    await expect(getSupabaseAuthStatus(input)).resolves.toEqual({
+      status: "connected",
+      auth: {
+        access: "saved-access",
+        refresh: "saved-refresh",
+        expires: expect.any(Number),
+      },
+      checked: false,
+    });
+  });
+
+  test("reports disconnected when no saved auth exists", async () => {
+    const { input } = await createInput();
+
+    await expect(getSupabaseAuthStatus(input)).resolves.toEqual({
+      status: "disconnected",
+      checked: false,
+    });
+  });
+
+  test("reports unknown when refresh fails for broker availability reasons", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "broker_unavailable",
+              message: "broker unavailable",
+            },
+          }),
+          { status: 502, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    await expect(getSupabaseAuthStatus(input, undefined, { fetch: fetchMock })).resolves.toEqual({
+      status: "unknown",
+      checked: true,
+      message: "Supabase auth refresh failed: broker unavailable",
+    });
+  });
+
+  test("disconnect helper clears saved auth and host auth", async () => {
+    const { input } = await createInput();
+    await writeSavedAuth(input, {
+      access: "saved-access",
+      refresh: "saved-refresh",
+      expires: Date.now() + 60_000,
+    });
+
+    const fetchMock: FetchLike = mock(async (request) => {
+      const url = String(request);
+      if (url === `http://127.0.0.1:7777/auth/supabase?directory=${encodeURIComponent(input.directory)}`) {
+        return new Response(JSON.stringify(true), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    await disconnectSupabaseAuth(input, { fetch: fetchMock });
+
+    await expect(readSavedAuth(input)).resolves.toEqual({ version: 1 });
   });
 
   test("clears saved auth and host auth when refresh is unauthorized", async () => {

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -318,6 +318,7 @@ describe("server tools auth helper", () => {
     await disconnectSupabaseAuth(input, { fetch: fetchMock });
 
     await expect(readSavedAuth(input)).resolves.toEqual({ version: 1 });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
   test("clears saved auth and host auth when refresh is unauthorized", async () => {

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -532,6 +532,448 @@ describe("server tools auth helper", () => {
     });
   });
 
+  test("concurrent stale-auth refresh callers for the same store should join one broker refresh", async () => {
+    const { hostAuthSet, input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    let brokerRefreshCalls = 0;
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      expect(url).toBe("https://example.com/broker/refresh");
+      expect(init?.method).toBe("POST");
+      brokerRefreshCalls += 1;
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      return new Response(
+        JSON.stringify({
+          access_token: `fresh-access-${brokerRefreshCalls}`,
+          refresh_token: `fresh-refresh-${brokerRefreshCalls}`,
+          expires_in: 3600,
+          token_type: "bearer",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+
+    const [firstAuth, secondAuth] = await Promise.all([
+      ensureSupabaseToolAuth(
+        input,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17686,
+        },
+        { fetch: fetchMock },
+      ),
+      ensureSupabaseToolAuth(
+        input,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17686,
+        },
+        { fetch: fetchMock },
+      ),
+    ]);
+
+    expect(firstAuth).toEqual(secondAuth);
+    expect(brokerRefreshCalls).toBe(1);
+    expect(hostAuthSet).toHaveBeenCalledTimes(1);
+  });
+
+  test("stale-auth callers from different directories in one worktree still sync host auth per directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opencode-supabase-tools-"));
+    cleanupPaths.push(root);
+    const firstHostAuthSet = mock(async () => ({ data: true }));
+    const secondHostAuthSet = mock(async () => ({ data: true }));
+    const firstInput = {
+      client: {
+        auth: {
+          set: firstHostAuthSet,
+        },
+      },
+      directory: join(root, "consumer-a"),
+      worktree: root,
+      serverUrl: new URL("http://127.0.0.1:7777/"),
+    } satisfies TestPluginInput;
+    const secondInput = {
+      client: {
+        auth: {
+          set: secondHostAuthSet,
+        },
+      },
+      directory: join(root, "consumer-b"),
+      worktree: root,
+      serverUrl: new URL("http://127.0.0.1:7777/"),
+    } satisfies TestPluginInput;
+
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(firstInput, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    let brokerRefreshCalls = 0;
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      expect(url).toBe("https://example.com/broker/refresh");
+      expect(init?.method).toBe("POST");
+      brokerRefreshCalls += 1;
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      return new Response(
+        JSON.stringify({
+          access_token: "fresh-access",
+          refresh_token: "fresh-refresh",
+          expires_in: 3600,
+          token_type: "bearer",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+
+    const [firstAuth, secondAuth] = await Promise.all([
+      ensureSupabaseToolAuth(
+        firstInput,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17686,
+        },
+        { fetch: fetchMock },
+      ),
+      ensureSupabaseToolAuth(
+        secondInput,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17686,
+        },
+        { fetch: fetchMock },
+      ),
+    ]);
+
+    expect(firstAuth).toEqual(secondAuth);
+    expect(brokerRefreshCalls).toBe(1);
+    expect(firstHostAuthSet).toHaveBeenCalledTimes(1);
+    expect(secondHostAuthSet).toHaveBeenCalledTimes(1);
+  });
+
+  test("late joined directory still syncs host auth while leader sync is pending", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opencode-supabase-tools-"));
+    cleanupPaths.push(root);
+    let releaseFirstHostSync: (() => void) | undefined;
+    let markFirstHostSyncStarted: (() => void) | undefined;
+    const firstHostSyncStarted = new Promise<void>((resolve) => {
+      markFirstHostSyncStarted = resolve;
+    });
+    let secondPromise: Promise<Awaited<ReturnType<typeof ensureSupabaseToolAuth>>> | undefined;
+    const secondHostAuthSet = mock(async () => ({ data: true }));
+    const secondInput = {
+      client: {
+        auth: {
+          set: secondHostAuthSet,
+        },
+      },
+      directory: join(root, "consumer-b"),
+      worktree: root,
+      serverUrl: new URL("http://127.0.0.1:7777/"),
+    } satisfies TestPluginInput;
+    let brokerRefreshCalls = 0;
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      expect(url).toBe("https://example.com/broker/refresh");
+      expect(init?.method).toBe("POST");
+      brokerRefreshCalls += 1;
+
+      return new Response(
+        JSON.stringify({
+          access_token: "fresh-access",
+          refresh_token: "fresh-refresh",
+          expires_in: 3600,
+          token_type: "bearer",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+    const firstHostAuthSet = mock(async () => {
+      markFirstHostSyncStarted?.();
+      secondPromise ??= ensureSupabaseToolAuth(
+        secondInput,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17686,
+        },
+        { fetch: fetchMock },
+      );
+      await new Promise<void>((resolve) => {
+        releaseFirstHostSync = resolve;
+      });
+      return { data: true };
+    });
+    const firstInput = {
+      client: {
+        auth: {
+          set: firstHostAuthSet,
+        },
+      },
+      directory: join(root, "consumer-a"),
+      worktree: root,
+      serverUrl: new URL("http://127.0.0.1:7777/"),
+    } satisfies TestPluginInput;
+
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(firstInput, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    const firstPromise = ensureSupabaseToolAuth(
+      firstInput,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17686,
+      },
+      { fetch: fetchMock },
+    );
+
+    await firstHostSyncStarted;
+
+    releaseFirstHostSync?.();
+
+    const resolvedSecondPromise = secondPromise;
+    if (!resolvedSecondPromise) {
+      throw new Error("Expected second promise to start during leader host sync");
+    }
+
+    const [firstAuth, secondAuth] = await Promise.all([firstPromise, resolvedSecondPromise]);
+
+    expect(firstAuth).toEqual(secondAuth);
+    expect(brokerRefreshCalls).toBe(1);
+    expect(firstHostAuthSet).toHaveBeenCalledTimes(1);
+    expect(secondHostAuthSet).toHaveBeenCalledTimes(1);
+  });
+
+  test("disconnect wins if a stale-auth refresh is still in flight", async () => {
+    const { hostAuthSet, input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    let resolveRefresh: (() => void) | undefined;
+    let markRefreshStarted: (() => void) | undefined;
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      expect(url).toBe("https://example.com/broker/refresh");
+      expect(init?.method).toBe("POST");
+      markRefreshStarted?.();
+
+      await new Promise<void>((resolve) => {
+        resolveRefresh = resolve;
+      });
+
+      return new Response(
+        JSON.stringify({
+          access_token: "fresh-access",
+          refresh_token: "fresh-refresh",
+          expires_in: 3600,
+          token_type: "bearer",
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
+    });
+
+    const refreshPromise = ensureSupabaseToolAuth(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17686,
+      },
+      { fetch: fetchMock },
+    );
+
+    await refreshStarted;
+
+    await disconnectSupabaseAuth(input, { fetch: mock(async () => new Response(null, { status: 204 })) });
+
+    resolveRefresh?.();
+
+    await expect(refreshPromise).rejects.toThrow("Supabase is not connected. Run /supabase first.");
+    await expect(readSavedAuth(input)).resolves.toEqual({ version: 1 });
+    expect(hostAuthSet).not.toHaveBeenCalled();
+  });
+
+  test("stale refresh failure does not clear newer auth written mid-flight", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(input, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    let resolveRefresh: (() => void) | undefined;
+    let markRefreshStarted: (() => void) | undefined;
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    const hostClearFetch: FetchLike = mock(async () => new Response(null, { status: 204 }));
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        expect(init?.method).toBe("POST");
+        markRefreshStarted?.();
+
+        await new Promise<void>((resolve) => {
+          resolveRefresh = resolve;
+        });
+
+        return new Response(
+          JSON.stringify({
+            error: "unauthorized",
+            message: "upstream token request was rejected",
+          }),
+          {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return hostClearFetch(request, init);
+    });
+
+    const refreshPromise = ensureSupabaseToolAuth(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17686,
+      },
+      { fetch: fetchMock },
+    );
+
+    await refreshStarted;
+
+    const newerAuth = {
+      access: "newer-access",
+      refresh: "newer-refresh",
+      expires: Date.now() + 60_000,
+    };
+    await writeSavedAuth(input, newerAuth);
+
+    resolveRefresh?.();
+
+    await expect(refreshPromise).resolves.toEqual(newerAuth);
+    await expect(readSavedAuth(input)).resolves.toEqual({ version: 1, auth: newerAuth });
+    expect(hostClearFetch).not.toHaveBeenCalled();
+  });
+
+  test("shared stale refresh rejection clears host auth for each joined directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opencode-supabase-tools-"));
+    cleanupPaths.push(root);
+    const firstInput = {
+      client: {
+        auth: {
+          set: mock(async () => ({ data: true })),
+        },
+      },
+      directory: join(root, "consumer-a"),
+      worktree: root,
+      serverUrl: new URL("http://127.0.0.1:7777/"),
+    } satisfies TestPluginInput;
+    const secondInput = {
+      client: {
+        auth: {
+          set: mock(async () => ({ data: true })),
+        },
+      },
+      directory: join(root, "consumer-b"),
+      worktree: root,
+      serverUrl: new URL("http://127.0.0.1:7777/"),
+    } satisfies TestPluginInput;
+
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(firstInput, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    let brokerRefreshCalls = 0;
+    let hostClearCalls = 0;
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        brokerRefreshCalls += 1;
+        return new Response(
+          JSON.stringify({
+            error: "unauthorized",
+            message: "upstream token request was rejected",
+          }),
+          {
+            status: 401,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (url.startsWith("http://127.0.0.1:7777/auth/supabase?directory=")) {
+        expect(init?.method).toBe("DELETE");
+        hostClearCalls += 1;
+        return new Response(null, { status: 204 });
+      }
+
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+
+    await expect(
+      Promise.all([
+        ensureSupabaseToolAuth(
+          firstInput,
+          {
+            clientId: "plugin-client",
+            oauthPort: 17686,
+          },
+          { fetch: fetchMock },
+        ),
+        ensureSupabaseToolAuth(
+          secondInput,
+          {
+            clientId: "plugin-client",
+            oauthPort: 17686,
+          },
+          { fetch: fetchMock },
+        ),
+      ]),
+    ).rejects.toThrow("Supabase is not connected. Run /supabase first.");
+
+    expect(brokerRefreshCalls).toBe(1);
+    expect(hostClearCalls).toBe(2);
+  });
+
   test("refreshes session-scoped auth when worktree is unrelated", async () => {
     const { hostAuthSet, input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";


### PR DESCRIPTION
## Summary

Adds preflight auth-state detection to the `/supabase` slash command so users see context-aware UI instead of always entering the OAuth flow.

## Changes

- **Server auth bridge** (`src/server/auth.ts`)
  - New `Supabase Status` auth method (index 1) that returns JSON status via `instructions`.
  - Supports `inputs.action=disconnect` to clear saved + host auth.
  - Refresh-required path reuses `ensureSupabaseToolAuth`; returns `failed` on invalid refresh token.

- **Server tools** (`src/server/tools.ts`)
  - Added `getSupabaseAuthStatus` and `disconnectSupabaseAuth` helpers.

- **TUI dialog** (`src/tui/dialog.tsx`)
  - Default dialog now starts with `checking_auth` state.
  - New states: `already_connected` (with disconnect option) and `unknown` (with retry/continue options).
  - `runAuthPreflight` calls status method, then callback only when refresh is needed.

- **Tests**
  - Added coverage for status method, disconnect action, refresh-denied callback, preflight state transitions, and dialog UX.

## Verification

- `bun test`: 130 pass, 0 fail
- `bunx tsc --noEmit`: clean
- `bunx biome check .`: clean