### PR TITLE
fix(ci): use file:// spec to avoid npm arborist hang

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
           export XDG_CACHE_HOME="$HOME/.cache"
 
           TARBALL="$(npm pack --json | jq -r '.[0].filename')"
-          SPEC="opencode-supabase@file:$(pwd)/$TARBALL"
+          SPEC="file://$(pwd)/$TARBALL"
 
           WORKDIR="$(mktemp -d)"
           cd "$WORKDIR"


### PR DESCRIPTION
## Summary

- `opencode-supabase@file:...` format not recognized by `isPathPluginSpec()`, falls to `Npm.add()` → `arborist.reify()` which hangs in empty temp workdir
- `file://$(pwd)/...` matches path spec detection, bypasses npm entirely
- TGZ stays unextracted. Config patching reads parent dir's `package.json` for exports detection
- No network, no npm resolution

## Verification

CI plugin-smoke job should complete instead of timing out at 365min.