### PR TITLE
feat: post-auth chat onboarding via promptAsync with ignored text part

### DIFF
--- a/.changeset/disconnect-toast.md
+++ b/.changeset/disconnect-toast.md
@@ -1,0 +1,7 @@
+---
+"opencode-supabase": patch
+---
+
+## Features
+
+- **Disconnect toast**: Show a confirmation toast after successfully disconnecting from Supabase.

--- a/.changeset/friendly-onboarding.md
+++ b/.changeset/friendly-onboarding.md
@@ -6,3 +6,4 @@
 
 - **Friendlier onboarding text**: Simplified post-auth chat onboarding message to be more concise and less formal.
 - **Dismissed OAuth feedback**: Show a confirmation toast when OAuth succeeds after the user dismissed the waiting dialog.
+- **Success dialog single OK button**: Changed success state from DialogConfirm (Cancel/Confirm) to DialogAlert (single OK) for cleaner UX.

--- a/.changeset/friendly-onboarding.md
+++ b/.changeset/friendly-onboarding.md
@@ -1,0 +1,7 @@
+---
+"opencode-supabase": patch
+---
+
+## UI Improvements
+
+- **Friendlier onboarding text**: Simplified post-auth chat onboarding message to be more concise and less formal.

--- a/.changeset/friendly-onboarding.md
+++ b/.changeset/friendly-onboarding.md
@@ -5,4 +5,4 @@
 ## UI Improvements
 
 - **Friendlier onboarding text**: Simplified post-auth chat onboarding message to be more concise and less formal.
-- **Dismissed OAuth feedback**: Show a toast when OAuth succeeds after the user dismissed the waiting dialog, with instructions to rerun `/supabase` if they want chat onboarding.
+- **Dismissed OAuth feedback**: Show a confirmation toast when OAuth succeeds after the user dismissed the waiting dialog.

--- a/.changeset/friendly-onboarding.md
+++ b/.changeset/friendly-onboarding.md
@@ -5,3 +5,4 @@
 ## UI Improvements
 
 - **Friendlier onboarding text**: Simplified post-auth chat onboarding message to be more concise and less formal.
+- **Dismissed OAuth feedback**: Show a toast when OAuth succeeds after the user dismissed the waiting dialog, with instructions to rerun `/supabase` if they want chat onboarding.

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -478,12 +478,9 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
     });
   }
 
-  return props.api.ui.DialogConfirm({
+  return props.api.ui.DialogAlert({
     title: "Connected to Supabase",
     message: "Your account is ready. Close this dialog and ask me to list your Supabase projects.",
-    onConfirm: () => {
-      closeDialog();
-    },
-    onCancel: closeDialog,
+    onConfirm: closeDialog,
   });
 }

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -13,8 +13,25 @@ type SupabaseDialogProps = {
     closed: boolean;
     dismissed?: boolean;
     preflightPromise?: Promise<void>;
+    onboardingPromptSent?: boolean;
   };
 };
+
+const ONBOARDING_MESSAGE = `Supabase is connected.
+
+What you can ask me to do now:
+- list my Supabase projects
+- inspect a Supabase project
+- list tables and database schemas
+- check migrations and database changes
+- review RLS policies and security advisors
+- help build or debug Supabase features
+- explain how this app connects to Supabase
+
+Good first prompt:
+list my Supabase projects`;
+
+const onboardedSessionIDsByApi = new WeakMap<TuiPluginApi, Set<string>>();
 
 type OAuthState =
   | { type: "checking_auth" }
@@ -43,7 +60,7 @@ type AuthFlowContext = {
   api: TuiPluginApi;
   logger: SupabaseLogger;
   setState: (state: OAuthState) => void;
-  onSuccess: () => void;
+  onSuccess: () => void | Promise<void>;
 };
 
 function getErrorMessage(error: unknown) {
@@ -69,6 +86,66 @@ async function openBrowser(url: string, logger: SupabaseLogger) {
     await open.default(url);
   } catch (error) {
     await logger.warn("supabase browser open failed", {
+      message: getErrorMessage(error),
+    });
+  }
+}
+
+async function injectOnboardingPrompt(
+  api: TuiPluginApi,
+  logger: SupabaseLogger,
+  lifecycle: NonNullable<SupabaseDialogProps["lifecycle"]>,
+) {
+  if (lifecycle.onboardingPromptSent) {
+    return;
+  }
+
+  const currentRoute = api.route.current;
+  let sessionID =
+    currentRoute.name === "session" ? (currentRoute.params as { sessionID?: string } | undefined)?.sessionID : undefined;
+
+  if (!sessionID && currentRoute.name === "home") {
+    const response = await api.client.session.create({});
+    sessionID = (response.data as { id?: string } | undefined)?.id;
+    if (sessionID) {
+      api.route.navigate("session", { sessionID });
+    }
+  }
+
+  if (!sessionID) {
+    await logger.warn("supabase onboarding prompt skipped", {
+      reason: "missing_session",
+    });
+    return;
+  }
+
+  const onboardedSessionIDs = onboardedSessionIDsByApi.get(api) ?? new Set<string>();
+  onboardedSessionIDsByApi.set(api, onboardedSessionIDs);
+
+  if (onboardedSessionIDs.has(sessionID)) {
+    lifecycle.onboardingPromptSent = true;
+    return;
+  }
+
+  lifecycle.onboardingPromptSent = true;
+  onboardedSessionIDs.add(sessionID);
+
+  try {
+    await api.client.session.promptAsync({
+      sessionID,
+      noReply: true,
+      parts: [
+        {
+          type: "text",
+          text: ONBOARDING_MESSAGE,
+          ignored: true,
+        },
+      ],
+    });
+  } catch (error) {
+    lifecycle.onboardingPromptSent = false;
+    onboardedSessionIDs.delete(sessionID);
+    await logger.warn("supabase onboarding prompt failed", {
       message: getErrorMessage(error),
     });
   }
@@ -145,7 +222,7 @@ export async function runAuthFlow(context: AuthFlowContext) {
 
   if (completed) {
     try {
-      context.onSuccess();
+      await context.onSuccess();
     } catch (error) {
       await context.logger.error("supabase auth success handler failed", {
         message: getErrorMessage(error),
@@ -255,7 +332,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       logger: props.logger,
       setState,
       onSuccess: () => {
-        // Success dialog handles user-facing confirmation
+        return injectOnboardingPrompt(props.api, props.logger, lifecycle);
       },
     });
 
@@ -361,7 +438,10 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
     return props.api.ui.DialogConfirm({
       title: "You're all set",
       message: "Your Supabase account is connected and ready to go.\n\nClose this dialog to continue, or disconnect to sign out.",
-      onConfirm: closeDialog,
+      onConfirm: async () => {
+        await injectOnboardingPrompt(props.api, props.logger, lifecycle);
+        closeDialog();
+      },
       onCancel: disconnect,
       label: "Disconnect",
     } as import("./opencode-runtime-extensions.ts").DialogConfirmWithLabel);
@@ -379,17 +459,8 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
   return props.api.ui.DialogConfirm({
     title: "Connected to Supabase",
     message:
-      "Your account is ready. Try asking:\n\n  list my Supabase projects\n  list my Supabase organizations\n  for organization <name>, list available regions\n\nHit Confirm to try it out",
-    onConfirm: async () => {
-      try {
-        await props.api.client.tui.appendPrompt({
-          text: "list my Supabase projects",
-        });
-      } catch (error) {
-        await props.logger.warn("supabase append prompt failed", {
-          message: getErrorMessage(error),
-        });
-      }
+      "Your account is ready. I added next steps to the current chat so you can pick a Supabase task from there.",
+    onConfirm: () => {
       closeDialog();
     },
     onCancel: closeDialog,

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -338,7 +338,14 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       logger: props.logger,
       setState,
       onSuccess: () => {
-        if (lifecycle.closed || lifecycle.dismissed) {
+        if (lifecycle.dismissed) {
+          props.api.ui.toast({
+            message: "Supabase connected. Run /supabase again to add onboarding to chat.",
+          });
+          return;
+        }
+
+        if (lifecycle.closed) {
           return;
         }
 

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -91,6 +91,12 @@ async function openBrowser(url: string, logger: SupabaseLogger) {
   }
 }
 
+function waitForNextMacrotask() {
+  return new Promise<void>((resolve) => {
+    setTimeout(resolve, 0);
+  });
+}
+
 async function injectOnboardingPrompt(
   api: TuiPluginApi,
   logger: SupabaseLogger,
@@ -103,11 +109,13 @@ async function injectOnboardingPrompt(
   const currentRoute = api.route.current;
   let sessionID =
     currentRoute.name === "session" ? (currentRoute.params as { sessionID?: string } | undefined)?.sessionID : undefined;
+  let createdSessionFromHome = false;
 
   if (!sessionID && currentRoute.name === "home") {
     const response = await api.client.session.create({});
     sessionID = (response.data as { id?: string } | undefined)?.id;
     if (sessionID) {
+      createdSessionFromHome = true;
       api.route.navigate("session", { sessionID });
     }
   }
@@ -131,6 +139,10 @@ async function injectOnboardingPrompt(
   onboardedSessionIDs.add(sessionID);
 
   try {
+    if (createdSessionFromHome) {
+      await waitForNextMacrotask();
+    }
+
     await api.client.session.promptAsync({
       sessionID,
       noReply: true,

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -20,14 +20,13 @@ type SupabaseDialogProps = {
 
 const ONBOARDING_MESSAGE = `Supabase is connected.
 
-What you can ask me to do now:
-- list your Supabase organizations
-- list your Supabase projects
-- get API keys for a project
-- list available database regions for an organization
-- create a new Supabase project
+You can ask me about:
+- your organizations and projects
+- API keys for a project
+- available database regions
+- creating a new project
 
-Good first prompt:
+Try this:
 list my Supabase projects`;
 
 const onboardedSessionIDsByApi = new WeakMap<TuiPluginApi, Set<string>>();
@@ -367,6 +366,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
         method: 1,
         inputs: { action: "disconnect" },
       });
+      props.api.ui.toast({ message: "Disconnected from Supabase" });
       closeDialog();
     } catch (error) {
       await props.logger.warn("supabase disconnect failed", {

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -338,6 +338,10 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       logger: props.logger,
       setState,
       onSuccess: () => {
+        if (lifecycle.closed || lifecycle.dismissed) {
+          return;
+        }
+
         return injectOnboardingPrompt(props.api, props.logger, lifecycle);
       },
     });
@@ -469,8 +473,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
   return props.api.ui.DialogConfirm({
     title: "Connected to Supabase",
-    message:
-      "Your account is ready. I added next steps to the current chat so you can pick a Supabase task from there.",
+    message: "Your account is ready. Return to the current chat to pick a Supabase task when you're ready.",
     onConfirm: () => {
       closeDialog();
     },

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -14,6 +14,7 @@ type SupabaseDialogProps = {
     dismissed?: boolean;
     preflightPromise?: Promise<void>;
     onboardingPromptSent?: boolean;
+    chatSessionID?: string;
   };
 };
 
@@ -91,10 +92,20 @@ async function openBrowser(url: string, logger: SupabaseLogger) {
   }
 }
 
-function waitForNextMacrotask() {
-  return new Promise<void>((resolve) => {
-    setTimeout(resolve, 0);
-  });
+async function ensureChatSession(api: TuiPluginApi) {
+  const currentRoute = api.route.current;
+  let sessionID =
+    currentRoute.name === "session" ? (currentRoute.params as { sessionID?: string } | undefined)?.sessionID : undefined;
+
+  if (!sessionID && currentRoute.name === "home") {
+    const response = await api.client.session.create({});
+    sessionID = (response.data as { id?: string } | undefined)?.id;
+    if (sessionID) {
+      api.route.navigate("session", { sessionID });
+    }
+  }
+
+  return sessionID;
 }
 
 async function injectOnboardingPrompt(
@@ -106,27 +117,14 @@ async function injectOnboardingPrompt(
     return;
   }
 
-  const currentRoute = api.route.current;
-  let sessionID =
-    currentRoute.name === "session" ? (currentRoute.params as { sessionID?: string } | undefined)?.sessionID : undefined;
-  let createdSessionFromHome = false;
-
-  if (!sessionID && currentRoute.name === "home") {
-    const response = await api.client.session.create({});
-    sessionID = (response.data as { id?: string } | undefined)?.id;
-    if (sessionID) {
-      createdSessionFromHome = true;
-      api.route.navigate("session", { sessionID });
-    }
-  }
-
-  if (!sessionID) {
+  if (!lifecycle.chatSessionID) {
     await logger.warn("supabase onboarding prompt skipped", {
       reason: "missing_session",
     });
     return;
   }
 
+  const sessionID = lifecycle.chatSessionID;
   const onboardedSessionIDs = onboardedSessionIDsByApi.get(api) ?? new Set<string>();
   onboardedSessionIDsByApi.set(api, onboardedSessionIDs);
 
@@ -139,10 +137,6 @@ async function injectOnboardingPrompt(
   onboardedSessionIDs.add(sessionID);
 
   try {
-    if (createdSessionFromHome) {
-      await waitForNextMacrotask();
-    }
-
     await api.client.session.promptAsync({
       sessionID,
       noReply: true,
@@ -338,8 +332,11 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
     );
   };
 
-  const startOAuth = () =>
-    runAuthFlow({
+  const startOAuth = async () => {
+    if (!lifecycle.chatSessionID) {
+      lifecycle.chatSessionID = await ensureChatSession(props.api);
+    }
+    return runAuthFlow({
       api: props.api,
       logger: props.logger,
       setState,
@@ -347,6 +344,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
         return injectOnboardingPrompt(props.api, props.logger, lifecycle);
       },
     });
+  };
 
   const retryPreflight = () => {
     if (lifecycle.preflightPromise) {
@@ -451,6 +449,9 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       title: "You're all set",
       message: "Your Supabase account is connected and ready to go.\n\nClose this dialog to continue, or disconnect to sign out.",
       onConfirm: async () => {
+        if (!lifecycle.chatSessionID) {
+          lifecycle.chatSessionID = await ensureChatSession(props.api);
+        }
         await injectOnboardingPrompt(props.api, props.logger, lifecycle);
         closeDialog();
       },

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -340,7 +340,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       onSuccess: () => {
         if (lifecycle.dismissed) {
           props.api.ui.toast({
-            message: "Supabase connected. Run /supabase again to add onboarding to chat.",
+            message: "Supabase connected",
           });
           return;
         }

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -21,13 +21,11 @@ type SupabaseDialogProps = {
 const ONBOARDING_MESSAGE = `Supabase is connected.
 
 What you can ask me to do now:
-- list my Supabase projects
-- inspect a Supabase project
-- list tables and database schemas
-- check migrations and database changes
-- review RLS policies and security advisors
-- help build or debug Supabase features
-- explain how this app connects to Supabase
+- list your Supabase organizations
+- list your Supabase projects
+- get API keys for a project
+- list available database regions for an organization
+- create a new Supabase project
 
 Good first prompt:
 list my Supabase projects`;

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -473,7 +473,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
   return props.api.ui.DialogConfirm({
     title: "Connected to Supabase",
-    message: "Your account is ready. Return to the current chat to pick a Supabase task when you're ready.",
+    message: "Your account is ready. Close this dialog and ask me to list your Supabase projects.",
     onConfirm: () => {
       closeDialog();
     },

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -344,7 +344,7 @@ test("supabase dialog success closes without inserting an example prompt", async
 
   expect(successDialog.title).toBe("Connected to Supabase");
   expect(successDialog.message).toBe(
-    "Your account is ready. Return to the current chat to pick a Supabase task when you're ready.",
+    "Your account is ready. Close this dialog and ask me to list your Supabase projects.",
   );
 
   await successDialog.onConfirm?.();

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -350,6 +350,9 @@ test("supabase dialog success closes without inserting an example prompt", async
   expect(successDialog.message).toBe(
     "Your account is ready. Close this dialog and ask me to list your Supabase projects.",
   );
+  expect((successDialog as Record<string, unknown>).onCancel).toBeUndefined();
+  expect(api.__test.dialogAlerts).toHaveLength(1);
+  expect(api.__test.dialogConfirms).toHaveLength(0);
 
   await successDialog.onConfirm?.();
 

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -348,48 +348,9 @@ test("supabase auth success injects ignored onboarding into current session", as
   expect(api.__test.promptOps).toEqual([]);
 });
 
-test("supabase auth success creates a session from home before onboarding", async () => {
-  const api = createDialogApi();
-  const lifecycle = { closed: false };
-
-  const dialog = SupabaseDialog({
-    api: api as never,
-    logger: createLogger(),
-    onClose: () => api.ui.dialog.clear(),
-    initialState: { type: "idle" },
-    lifecycle,
-  }) as { onConfirm?: () => Promise<void> };
-
-  await dialog.onConfirm?.();
-  await Promise.resolve();
-
-  expect(api.__test.sessionOps).toEqual([
-    { op: "create", payload: {} },
-    expect.objectContaining({
-      op: "promptAsync",
-      payload: expect.objectContaining({ sessionID: "session-created", noReply: true }),
-    }),
-  ]);
-  expect(api.__test.routeOps).toEqual([
-    { op: "navigate", name: "session", params: { sessionID: "session-created" } },
-  ]);
-});
-
-test("supabase auth success waits for session navigation to settle before onboarding from home", async () => {
-  let sessionRouteReady = false;
-
+test("supabase auth success creates a session from home before OAuth not after", async () => {
+  const ops: string[] = [];
   const api = createDialogApi({
-    route: {
-      current: {
-        name: "home",
-      },
-      navigate: (name: string, params?: unknown) => {
-        api.__test.routeOps.push({ op: "navigate", name, params });
-        queueMicrotask(() => {
-          sessionRouteReady = true;
-        });
-      },
-    },
     client: {
       app: {
         log: (_input: unknown) => Promise.resolve(true),
@@ -401,21 +362,26 @@ test("supabase auth success waits for session navigation to settle before onboar
       },
       session: {
         create: (input?: unknown) => {
+          ops.push("create");
           api.__test.sessionOps.push({ op: "create", payload: input });
           return Promise.resolve({ data: { id: "session-created" } });
         },
         promptAsync: (input: unknown) => {
-          if (!sessionRouteReady) {
-            throw new Error("promptAsync called before session navigation settled");
-          }
+          ops.push("promptAsync");
           api.__test.sessionOps.push({ op: "promptAsync", payload: input });
           return Promise.resolve({ data: true });
         },
       },
       provider: {
         oauth: {
-          authorize: () => Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } }),
-          callback: () => Promise.resolve({ data: true }),
+          authorize: () => {
+            ops.push("authorize");
+            return Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } });
+          },
+          callback: () => {
+            ops.push("callback");
+            return Promise.resolve({ data: true });
+          },
         },
       },
     },
@@ -433,13 +399,21 @@ test("supabase auth success waits for session navigation to settle before onboar
   await dialog.onConfirm?.();
   await Promise.resolve();
 
-  expect(api.__test.sessionOps).toEqual([
-    { op: "create", payload: {} },
-    expect.objectContaining({
-      op: "promptAsync",
-      payload: expect.objectContaining({ sessionID: "session-created", noReply: true }),
-    }),
+  // Session must be created and navigated BEFORE OAuth authorize runs
+  const createIdx = ops.indexOf("create");
+  const authorizeIdx = ops.indexOf("authorize");
+  expect(createIdx).toBeGreaterThan(-1);
+  expect(authorizeIdx).toBeGreaterThan(-1);
+  expect(createIdx).toBeLessThan(authorizeIdx);
+
+  expect(api.__test.routeOps).toEqual([
+    { op: "navigate", name: "session", params: { sessionID: "session-created" } },
   ]);
+
+  expect(api.__test.sessionOps).toContainEqual(expect.objectContaining({
+    op: "promptAsync",
+    payload: expect.objectContaining({ sessionID: "session-created", noReply: true }),
+  }));
 });
 
 test("supabase already-connected confirm injects onboarding once", async () => {
@@ -1045,6 +1019,7 @@ test("error retry starts fresh oauth without using stale url", async () => {
         submitPrompt: () => Promise.resolve({ data: true }),
       },
       session: {
+        create: () => Promise.resolve({ data: { id: "ses-retry" } }),
         promptAsync: () => Promise.resolve({ data: true }),
       },
       provider: {

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -339,7 +339,7 @@ test("supabase auth success injects ignored onboarding into current session", as
           expect.objectContaining({
             type: "text",
             ignored: true,
-            text: expect.stringContaining("list your Supabase organizations"),
+            text: expect.stringContaining("your organizations and projects"),
           }),
         ],
       },
@@ -663,6 +663,7 @@ test("supabase dialog already connected offers disconnect action", async () => {
 
   expect(authorizeCalls).toEqual([{ providerID: "supabase", method: 1, inputs: { action: "disconnect" } }]);
   expect(api.__test.cleared).toBe(1);
+  expect(api.__test.toasts).toEqual([{ message: "Disconnected from Supabase" }]);
 });
 
 test("supabase dialog starts preflight only once while first check is pending", async () => {

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -294,7 +294,7 @@ test("supabase dialog success closes without inserting an example prompt", async
 
   expect(successDialog.title).toBe("Connected to Supabase");
   expect(successDialog.message).toBe(
-    "Your account is ready. Try asking:\n\n  list my Supabase projects\n  list my Supabase organizations\n  for organization <name>, list available regions\n\nHit Confirm to try it out",
+    "Your account is ready. I added next steps to the current chat so you can pick a Supabase task from there.",
   );
 
   await successDialog.onConfirm?.();

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -240,35 +240,85 @@ test("tui plugin registers /supabase and opens a closable dialog", async () => {
   expect(cleared).toBe(0);
 });
 
-test("supabase dialog success is silent when waiting dialog was dismissed", async () => {
-  const api = createDialogApi();
+test("supabase dialog does not inject onboarding after waiting dialog was dismissed", async () => {
+  let currentDialog: unknown;
+  let releaseCallback!: () => void;
+
+  const api = createDialogApi({
+    route: {
+      current: {
+        name: "session",
+        params: { sessionID: "session-current" },
+      },
+      navigate: () => undefined,
+    },
+    ui: {
+      Dialog: (input: unknown) => input,
+      DialogAlert: (input: unknown) => {
+        currentDialog = input;
+        return input;
+      },
+      DialogConfirm: (input: unknown) => {
+        currentDialog = input;
+        return input;
+      },
+      toast: (input: { variant?: string; message: string }) => {
+        api.__test.toasts.push(input);
+      },
+      dialog: {
+        replace: (factory: () => unknown) => {
+          currentDialog = factory();
+        },
+        clear: () => undefined,
+      },
+    },
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        promptAsync: (input: unknown) => {
+          api.__test.sessionOps.push({ op: "promptAsync", payload: input });
+          return Promise.resolve({ data: true });
+        },
+      },
+      provider: {
+        oauth: {
+          authorize: () => Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } }),
+          callback: () =>
+            new Promise((resolve) => {
+              releaseCallback = () => resolve({ data: true });
+            }),
+        },
+      },
+    },
+  });
   const lifecycle = { closed: false, dismissed: false };
 
   const dialog = SupabaseDialog({
     api: api as never,
     logger: createLogger(),
     onClose: () => api.ui.dialog.clear(),
-    initialState: { type: "waiting_callback", url: "https://example.com/auth" },
+    initialState: { type: "idle" },
     lifecycle,
-  });
+  }) as { onConfirm?: () => Promise<void> };
 
-  // Trigger the waiting dialog's onConfirm (dismiss)
-  const waitingDialog = api.__test.dialogAlerts[0] as { onConfirm?: () => void };
-  waitingDialog?.onConfirm?.();
+  const authPromise = dialog.onConfirm?.();
+  await new Promise((resolve) => setTimeout(resolve, 0));
 
-  expect(api.__test.cleared).toBe(1);
+  expect(currentDialog).toMatchObject({ title: "Connect to Supabase" });
+  (currentDialog as { onConfirm?: () => void }).onConfirm?.();
   expect(lifecycle.dismissed).toBe(true);
 
-  // Now simulate success state transition through setState
-  // Since lifecycle is closed and dismissed, setState should not replace dialog
-  const initialConfirmCount = api.__test.dialogConfirms.length;
+  releaseCallback();
+  await authPromise;
 
-  // Manually invoke what setState would do (it checks lifecycle.closed internally)
-  // Since lifecycle.closed = true, setState would return early and do nothing
-  expect(lifecycle.closed).toBe(true);
-
-  // Verify no additional dialogs were created
-  expect(api.__test.dialogConfirms).toHaveLength(initialConfirmCount);
+  expect(api.__test.sessionOps.filter((op) => op.op === "promptAsync")).toHaveLength(0);
   expect(api.__test.toasts).toEqual([]);
 });
 
@@ -294,7 +344,7 @@ test("supabase dialog success closes without inserting an example prompt", async
 
   expect(successDialog.title).toBe("Connected to Supabase");
   expect(successDialog.message).toBe(
-    "Your account is ready. I added next steps to the current chat so you can pick a Supabase task from there.",
+    "Your account is ready. Return to the current chat to pick a Supabase task when you're ready.",
   );
 
   await successDialog.onConfirm?.();

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -42,12 +42,17 @@ function createDialogApi(overrides?: Record<string, unknown>) {
   const dialogConfirms: unknown[] = [];
   const toasts: Array<{ variant?: string; message: string }> = [];
   const promptOps: Array<{ op: string; payload?: unknown }> = [];
+  const sessionOps: Array<{ op: string; payload?: unknown }> = [];
+  const routeOps: Array<{ op: string; name: string; params?: unknown }> = [];
   let openCalls: string[] = [];
 
   const api = {
     route: {
       current: {
         name: "home",
+      },
+      navigate: (name: string, params?: unknown) => {
+        routeOps.push({ op: "navigate", name, params });
       },
     },
     ui: {
@@ -94,7 +99,14 @@ function createDialogApi(overrides?: Record<string, unknown>) {
         },
       },
       session: {
-        promptAsync: () => Promise.resolve({ data: true }),
+        create: (input?: unknown) => {
+          sessionOps.push({ op: "create", payload: input });
+          return Promise.resolve({ data: { id: "session-created" } });
+        },
+        promptAsync: (input: unknown) => {
+          sessionOps.push({ op: "promptAsync", payload: input });
+          return Promise.resolve({ data: true });
+        },
       },
       provider: {
         oauth: {
@@ -109,6 +121,8 @@ function createDialogApi(overrides?: Record<string, unknown>) {
       dialogConfirms,
       toasts,
       promptOps,
+      sessionOps,
+      routeOps,
       get cleared() {
         return cleared;
       },
@@ -131,6 +145,8 @@ function createDialogApi(overrides?: Record<string, unknown>) {
       dialogConfirms: unknown[];
       toasts: Array<{ variant?: string; message: string }>;
       promptOps: Array<{ op: string; payload?: unknown }>;
+      sessionOps: Array<{ op: string; payload?: unknown }>;
+      routeOps: Array<{ op: string; name: string; params?: unknown }>;
       cleared: number;
       replaced: number;
       openCalls: string[];
@@ -256,7 +272,7 @@ test("supabase dialog success is silent when waiting dialog was dismissed", asyn
   expect(api.__test.toasts).toEqual([]);
 });
 
-test("supabase dialog success shows example prompts and inserts on confirm", async () => {
+test("supabase dialog success closes without inserting an example prompt", async () => {
   const states: Array<Record<string, unknown>> = [];
   const api = createDialogApi();
 
@@ -283,16 +299,165 @@ test("supabase dialog success shows example prompts and inserts on confirm", asy
 
   await successDialog.onConfirm?.();
 
-  expect(api.__test.promptOps).toEqual([
-    {
-      op: "appendPrompt",
-      payload: { text: "list my Supabase projects" },
-    },
-  ]);
+  expect(api.__test.promptOps).toEqual([]);
   expect(api.__test.promptOps.some((op) => op.op === "submitPrompt")).toBe(false);
   expect(api.__test.cleared).toBe(1);
   expect(api.__test.toasts).toEqual([]);
   expect(states.at(-1)).toEqual({ type: "success" });
+});
+
+test("supabase auth success injects ignored onboarding into current session", async () => {
+  const api = createDialogApi({
+    route: {
+      current: {
+        name: "session",
+        params: { sessionID: "session-current" },
+      },
+      navigate: () => undefined,
+    },
+  });
+  const lifecycle = { closed: false };
+
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "idle" },
+    lifecycle,
+  }) as { onConfirm?: () => Promise<void> };
+
+  await dialog.onConfirm?.();
+  await Promise.resolve();
+
+  expect(api.__test.sessionOps).toEqual([
+    {
+      op: "promptAsync",
+      payload: {
+        sessionID: "session-current",
+        noReply: true,
+        parts: [
+          expect.objectContaining({
+            type: "text",
+            ignored: true,
+            text: expect.stringContaining("What you can ask me to do now:"),
+          }),
+        ],
+      },
+    },
+  ]);
+  expect(api.__test.promptOps).toEqual([]);
+});
+
+test("supabase auth success creates a session from home before onboarding", async () => {
+  const api = createDialogApi();
+  const lifecycle = { closed: false };
+
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "idle" },
+    lifecycle,
+  }) as { onConfirm?: () => Promise<void> };
+
+  await dialog.onConfirm?.();
+  await Promise.resolve();
+
+  expect(api.__test.sessionOps).toEqual([
+    { op: "create", payload: {} },
+    expect.objectContaining({
+      op: "promptAsync",
+      payload: expect.objectContaining({ sessionID: "session-created", noReply: true }),
+    }),
+  ]);
+  expect(api.__test.routeOps).toEqual([
+    { op: "navigate", name: "session", params: { sessionID: "session-created" } },
+  ]);
+});
+
+test("supabase already-connected confirm injects onboarding once", async () => {
+  const api = createDialogApi({
+    route: {
+      current: {
+        name: "session",
+        params: { sessionID: "session-current" },
+      },
+      navigate: () => undefined,
+    },
+  });
+  const lifecycle = { closed: false };
+
+  const firstDialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "already_connected" },
+    lifecycle,
+  }) as { onConfirm?: () => Promise<void> };
+
+  await firstDialog.onConfirm?.();
+  lifecycle.closed = false;
+
+  const secondDialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "already_connected" },
+    lifecycle,
+  }) as { onConfirm?: () => Promise<void> };
+
+  await secondDialog.onConfirm?.();
+
+  expect(api.__test.sessionOps.filter((op) => op.op === "promptAsync")).toHaveLength(1);
+});
+
+test("supabase already-connected confirm dedupes onboarding across dialog lifecycles", async () => {
+  const api = createDialogApi({
+    route: {
+      current: {
+        name: "session",
+        params: { sessionID: "session-current" },
+      },
+      navigate: () => undefined,
+    },
+  });
+
+  const firstDialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "already_connected" },
+    lifecycle: { closed: false },
+  }) as { onConfirm?: () => Promise<void> };
+
+  await firstDialog.onConfirm?.();
+
+  const secondDialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "already_connected" },
+    lifecycle: { closed: false },
+  }) as { onConfirm?: () => Promise<void> };
+
+  await secondDialog.onConfirm?.();
+
+  expect(api.__test.sessionOps.filter((op) => op.op === "promptAsync")).toHaveLength(1);
+});
+
+test("supabase disconnect does not inject onboarding", async () => {
+  const api = createDialogApi();
+
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "already_connected" },
+  }) as { onCancel?: () => Promise<void> };
+
+  await dialog.onCancel?.();
+
+  expect(api.__test.sessionOps).toEqual([]);
 });
 
 test("supabase auth preflight reports already connected when saved auth is still valid", async () => {

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -375,6 +375,73 @@ test("supabase auth success creates a session from home before onboarding", asyn
   ]);
 });
 
+test("supabase auth success waits for session navigation to settle before onboarding from home", async () => {
+  let sessionRouteReady = false;
+
+  const api = createDialogApi({
+    route: {
+      current: {
+        name: "home",
+      },
+      navigate: (name: string, params?: unknown) => {
+        api.__test.routeOps.push({ op: "navigate", name, params });
+        queueMicrotask(() => {
+          sessionRouteReady = true;
+        });
+      },
+    },
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        create: (input?: unknown) => {
+          api.__test.sessionOps.push({ op: "create", payload: input });
+          return Promise.resolve({ data: { id: "session-created" } });
+        },
+        promptAsync: (input: unknown) => {
+          if (!sessionRouteReady) {
+            throw new Error("promptAsync called before session navigation settled");
+          }
+          api.__test.sessionOps.push({ op: "promptAsync", payload: input });
+          return Promise.resolve({ data: true });
+        },
+      },
+      provider: {
+        oauth: {
+          authorize: () => Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } }),
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  });
+  const lifecycle = { closed: false };
+
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "idle" },
+    lifecycle,
+  }) as { onConfirm?: () => Promise<void> };
+
+  await dialog.onConfirm?.();
+  await Promise.resolve();
+
+  expect(api.__test.sessionOps).toEqual([
+    { op: "create", payload: {} },
+    expect.objectContaining({
+      op: "promptAsync",
+      payload: expect.objectContaining({ sessionID: "session-created", noReply: true }),
+    }),
+  ]);
+});
+
 test("supabase already-connected confirm injects onboarding once", async () => {
   const api = createDialogApi({
     route: {

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -339,7 +339,7 @@ test("supabase auth success injects ignored onboarding into current session", as
           expect.objectContaining({
             type: "text",
             ignored: true,
-            text: expect.stringContaining("What you can ask me to do now:"),
+            text: expect.stringContaining("list your Supabase organizations"),
           }),
         ],
       },

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -321,7 +321,7 @@ test("supabase dialog does not inject onboarding after waiting dialog was dismis
   expect(api.__test.sessionOps.filter((op) => op.op === "promptAsync")).toHaveLength(0);
   expect(api.__test.toasts).toEqual([
     {
-      message: "Supabase connected. Run /supabase again to add onboarding to chat.",
+      message: "Supabase connected",
     },
   ]);
 });

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -319,7 +319,11 @@ test("supabase dialog does not inject onboarding after waiting dialog was dismis
   await authPromise;
 
   expect(api.__test.sessionOps.filter((op) => op.op === "promptAsync")).toHaveLength(0);
-  expect(api.__test.toasts).toEqual([]);
+  expect(api.__test.toasts).toEqual([
+    {
+      message: "Supabase connected. Run /supabase again to add onboarding to chat.",
+    },
+  ]);
 });
 
 test("supabase dialog success closes without inserting an example prompt", async () => {


### PR DESCRIPTION
## Summary

After successful Supabase auth or confirming `already_connected` dialog, injects an onboarding message into the current chat session using `promptAsync({ noReply: true, parts: [{ type: "text", ignored: true, text: ONBOARDING_MESSAGE }] })`.

The `ignored: true` flag keeps the message visible to the user but invisible to the LLM — no context window pollution.

### Changes

- **`src/tui/dialog.tsx`** — new `injectOnboardingPrompt()` helper, called from fresh auth success handler and `already_connected` confirm. Creates/navigates to session if user starts from home. Dedupes per session via `WeakMap<TuiPluginApi, Set<string>>`. Removes old `appendPrompt("list my Supabase projects")` pattern.
- **`test/plugin-exports.test.ts`** — 5 new tests covering session injection, home-screen creation, `already_connected` dedupe (same lifecycle and across lifecycles), and no injection on disconnect.

### Verification

- `bun test`: 144 pass, 0 fail
- `bunx tsc --noEmit`: pass
- `bunx biome check .`: 36 files checked, no fixes applied