### PR TITLE
fix(tui): update Supabase dialog copy

### DIFF
--- a/.changeset/tame-bulldogs-drum.md
+++ b/.changeset/tame-bulldogs-drum.md
@@ -1,0 +1,5 @@
+---
+"opencode-supabase": patch
+---
+
+Update Supabase dialog copy to match the reviewed onboarding wording.

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -313,9 +313,8 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
   if (currentState.type === "idle") {
     return props.api.ui.DialogConfirm({
-      title: "Connect Supabase",
-      message:
-        "This will open a browser window to authorize OpenCode to access your Supabase account. Continue?",
+      title: "Connect your Supabase account",
+      message: "Opens your browser to authorize OpenCode to access your Supabase account.",
       onConfirm: startOAuth,
       onCancel: closeDialog,
     });
@@ -331,7 +330,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
     }
 
     return props.api.ui.DialogAlert({
-      title: "Connect Supabase",
+      title: "Connect to Supabase",
       message: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nWaiting for authorization...`,
       onConfirm: () => closeDialog(true),
     });
@@ -339,7 +338,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
   if (currentState.type === "waiting_callback") {
     return props.api.ui.DialogAlert({
-      title: "Connect Supabase",
+      title: "Connect to Supabase",
       message: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nWaiting for authorization...`,
       onConfirm: () => closeDialog(true),
     });
@@ -360,8 +359,8 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
   if (currentState.type === "already_connected") {
     return props.api.ui.DialogConfirm({
-      title: "Already connected to Supabase",
-      message: "Your saved Supabase login is ready to use. Continue to close this dialog, or disconnect to sign out.",
+      title: "You're all set",
+      message: "Your Supabase account is connected and ready to go.\n\nClose this dialog to continue, or disconnect to sign out.",
       onConfirm: closeDialog,
       onCancel: disconnect,
       label: "Disconnect",
@@ -380,7 +379,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
   return props.api.ui.DialogConfirm({
     title: "Connected to Supabase",
     message:
-      "Your account is ready. Try asking:\n\n  list my Supabase projects\n  list my Supabase organizations\n  for organization <name>, list available regions\n\nRun an example?",
+      "Your account is ready. Try asking:\n\n  list my Supabase projects\n  list my Supabase organizations\n  for organization <name>, list available regions\n\nHit Confirm to try it out",
     onConfirm: async () => {
       try {
         await props.api.client.tui.appendPrompt({

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -274,9 +274,12 @@ test("supabase dialog success shows example prompts and inserts on confirm", asy
     logger: createLogger(),
     onClose: () => api.ui.dialog.clear(),
     initialState: { type: "success" },
-  }) as { title?: string; onConfirm?: () => Promise<void> };
+  }) as { title?: string; message?: string; onConfirm?: () => Promise<void> };
 
   expect(successDialog.title).toBe("Connected to Supabase");
+  expect(successDialog.message).toBe(
+    "Your account is ready. Try asking:\n\n  list my Supabase projects\n  list my Supabase organizations\n  for organization <name>, list available regions\n\nHit Confirm to try it out",
+  );
 
   await successDialog.onConfirm?.();
 
@@ -446,7 +449,10 @@ test("supabase dialog already connected offers disconnect action", async () => {
     initialState: { type: "already_connected" },
   }) as { title?: string; message?: string; onCancel?: () => Promise<void> };
 
-  expect(dialog.title).toBe("Already connected to Supabase");
+  expect(dialog.title).toBe("You're all set");
+  expect(dialog.message).toBe(
+    "Your Supabase account is connected and ready to go.\n\nClose this dialog to continue, or disconnect to sign out.",
+  );
   await dialog.onCancel?.();
 
   expect(authorizeCalls).toEqual([{ providerID: "supabase", method: 1, inputs: { action: "disconnect" } }]);
@@ -517,7 +523,7 @@ test("supabase dialog starts preflight only once while first check is pending", 
   await Promise.resolve();
 
   expect(currentDialog).toMatchObject({
-    title: "Already connected to Supabase",
+    title: "You're all set",
   });
   expect(authorizeCalls).toBe(1);
 });
@@ -706,7 +712,8 @@ test("supabase dialog idle uses built in confirm dialog", () => {
   });
 
   expect(dialog).toMatchObject({
-    title: "Connect Supabase",
+    title: "Connect your Supabase account",
+    message: "Opens your browser to authorize OpenCode to access your Supabase account.",
   });
   expect(api.__test.dialogConfirms).toHaveLength(1);
   expect(api.__test.dialogs).toHaveLength(0);
@@ -722,7 +729,9 @@ test("supabase dialog waiting states use built in alert dialog", () => {
   });
 
   expect(waiting).toMatchObject({
-    title: "Connect Supabase",
+    title: "Connect to Supabase",
+    message:
+      "Complete authorization in your browser.\n\nIf the browser did not open, visit:\nhttps://example.com/auth\n\nWaiting for authorization...",
   });
   expect(api.__test.dialogAlerts).toHaveLength(1);
   expect(api.__test.dialogs).toHaveLength(0);


### PR DESCRIPTION
## Summary
- update Supabase onboarding dialog copy to match reviewed wording across idle, browser-auth, connected, and success states
- add exact TUI dialog copy assertions so the reviewed text stays covered by tests
- add a patch changeset for the wording update

## Test Plan
- [x] bun test test/plugin-exports.test.ts
- [x] bun test