### PR TITLE
feat(tui): add animated spinner dialog for Supabase auth flow

### DIFF
--- a/.changeset/friendly-onboarding.md
+++ b/.changeset/friendly-onboarding.md
@@ -5,5 +5,5 @@
 ## UI Improvements
 
 - **Friendlier onboarding text**: Simplified post-auth chat onboarding message to be more concise and less formal.
-- **Dismissed OAuth feedback**: Show a confirmation toast when OAuth succeeds after the user dismissed the waiting dialog.
+- **Dismissed OAuth feedback**: Use a `Dismiss` action for in-progress OAuth. Dismissing closes only the dialog; browser approval can still complete auth and show the success toast.
 - **Success dialog single OK button**: Changed success state from DialogConfirm (Cancel/Confirm) to DialogAlert (single OK) for cleaner UX.

--- a/.changeset/friendly-onboarding.md
+++ b/.changeset/friendly-onboarding.md
@@ -4,6 +4,6 @@
 
 ## UI Improvements
 
-- **Friendlier onboarding text**: Simplified post-auth chat onboarding message to be more concise and less formal.
-- **Dismissed OAuth feedback**: Use a `Dismiss` action for in-progress OAuth. Dismissing closes only the dialog; browser approval can still complete auth and show the success toast.
-- **Success dialog single OK button**: Changed success state from DialogConfirm (Cancel/Confirm) to DialogAlert (single OK) for cleaner UX.
+- **Supabase auth progress**: Replaced static auth checks with an animated spinner dialog, markdown instructions, and clearer "No action needed" preflight copy.
+- **OAuth dismiss behavior**: Renamed in-progress auth action to `Dismiss`. Dismiss closes only the dialog; browser approval can still complete auth and show the success toast.
+- **Connection flow polish**: Unified "Connect to Supabase" titles, shortened browser approval copy, simplified post-auth onboarding, and replaced the success dialog with a single OK action.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         run: bun run typecheck
 
       - name: Test
-        run: bun test
+        run: bun run test
 
       - name: Verify package
         run: bun run verify:pack

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint": "biome check .",
     "verify:pack": "npm pack --dry-run",
     "typecheck": "bunx tsc --noEmit",
-    "test": "bun test",
+    "test": "bun test --preload @opentui/solid/preload",
     "changeset": "changeset",
     "version-packages": "changeset version",
     "release": "changeset publish"

--- a/src/tui/commands.ts
+++ b/src/tui/commands.ts
@@ -1,6 +1,6 @@
 export function createSupabaseCommand(openDialog: () => void) {
   return {
-    title: "Connect Supabase",
+    title: "Connect to Supabase",
     value: "supabase.connect",
     slash: { name: "supabase" },
     onSelect: openDialog,

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -88,7 +88,10 @@ function getErrorMessage(error: unknown) {
 }
 
 function getDialogTheme(api: TuiPluginApi): DialogTheme {
-  return ((api as { theme?: { current?: DialogTheme } }).theme?.current ?? FALLBACK_THEME) as DialogTheme;
+  return {
+    ...FALLBACK_THEME,
+    ...((api as { theme?: { current?: Partial<DialogTheme> } }).theme?.current ?? {}),
+  } as DialogTheme;
 }
 
 function createMarkdownSyntax(theme: DialogTheme) {

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -501,9 +501,9 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
     return SupabaseSpinnerDialog({
       api: props.api,
-      title: "Connect Supabase",
+      title: "Connect to Supabase",
       status: "Checking Supabase connection...",
-      body: "Let this run. It should only take a few seconds.",
+      body: "No action needed. This should only take a few seconds.",
       onClose: () => undefined,
     });
   }
@@ -511,7 +511,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
   if (currentState.type === "idle") {
     return props.api.ui.DialogConfirm({
       title: "Connect your Supabase account",
-      message: "Opens your browser to authorize OpenCode to access your Supabase account.",
+      message: "Open your browser to authorize OpenCode to access your Supabase account.",
       onConfirm: startOAuth,
       onCancel: closeDialog,
     });
@@ -521,9 +521,9 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
     if (!currentState.url) {
       return SupabaseSpinnerDialog({
         api: props.api,
-        title: "Connect Supabase",
+        title: "Connect to Supabase",
         status: "Starting authorization...",
-        body: "Opening your browser. You can close this dialog; authorization only completes if you approve in browser.",
+        body: "Opening your browser. You can close this dialog; auth completes only after browser approval.",
         dismissible: true,
         onClose: () => closeDialog(true),
       });
@@ -533,7 +533,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       api: props.api,
       title: "Connect to Supabase",
       status: "Waiting for browser authorization...",
-      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nYou can close this dialog; authorization only completes if you approve in browser.`,
+      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nYou can close this dialog; auth completes only after browser approval.`,
       dismissible: true,
       size: "large",
       onClose: () => closeDialog(true),
@@ -544,8 +544,8 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
     return SupabaseSpinnerDialog({
       api: props.api,
       title: "Connect to Supabase",
-      status: "Waiting for authorization...",
-      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nYou can close this dialog; authorization only completes if you approve in browser.`,
+      status: "Waiting for browser authorization...",
+      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nYou can close this dialog; auth completes only after browser approval.`,
       dismissible: true,
       size: "large",
       onClose: () => closeDialog(true),

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -1,5 +1,7 @@
 import type { TuiPluginApi } from "@opencode-ai/plugin/tui";
-import { createSignal } from "solid-js";
+import { RGBA, SyntaxStyle, TextAttributes } from "@opentui/core";
+import { createSignal, onCleanup } from "solid-js";
+import type { JSX } from "solid-js";
 
 import { formatAuthError } from "../shared/auth-errors.ts";
 import type { SupabaseLogger } from "../shared/log.ts";
@@ -61,8 +63,107 @@ type AuthFlowContext = {
   onSuccess: () => void | Promise<void>;
 };
 
+const SPINNER_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+const FALLBACK_THEME = {
+  primary: RGBA.fromHex("#347d95"),
+  selectedListItemText: RGBA.fromHex("#ffffff"),
+  text: RGBA.fromHex("#f8f5ea"),
+  textMuted: RGBA.fromHex("#9f97aa"),
+  backgroundPanel: RGBA.fromHex("#f8f5ea"),
+  markdownText: RGBA.fromHex("#5f5875"),
+  markdownHeading: RGBA.fromHex("#5f5875"),
+  markdownLink: RGBA.fromHex("#347d95"),
+  markdownStrong: RGBA.fromHex("#5f5875"),
+  markdownEmph: RGBA.fromHex("#8a6f00"),
+  markdownCode: RGBA.fromHex("#2e7d32"),
+  markdownListItem: RGBA.fromHex("#347d95"),
+  markdownBlockQuote: RGBA.fromHex("#8a6f00"),
+};
+
+type DialogTheme = typeof FALLBACK_THEME;
+
 function getErrorMessage(error: unknown) {
   return error instanceof Error ? error.message : String(error);
+}
+
+function getDialogTheme(api: TuiPluginApi): DialogTheme {
+  return ((api as { theme?: { current?: DialogTheme } }).theme?.current ?? FALLBACK_THEME) as DialogTheme;
+}
+
+function createMarkdownSyntax(theme: DialogTheme) {
+  return SyntaxStyle.fromTheme([
+    { scope: ["markup.heading"], style: { foreground: theme.markdownHeading, bold: true } },
+    { scope: ["markup.bold", "markup.strong"], style: { foreground: theme.markdownStrong, bold: true } },
+    { scope: ["markup.italic"], style: { foreground: theme.markdownEmph, italic: true } },
+    { scope: ["markup.raw", "markup.raw.block", "markup.raw.inline"], style: { foreground: theme.markdownCode } },
+    { scope: ["markup.link", "markup.link.url"], style: { foreground: theme.markdownLink, underline: true } },
+    { scope: ["markup.list"], style: { foreground: theme.markdownListItem } },
+    { scope: ["markup.quote"], style: { foreground: theme.markdownBlockQuote, italic: true } },
+    { scope: ["conceal"], style: { foreground: theme.textMuted } },
+  ]);
+}
+
+function SpinnerLabel(props: { text: string; color: DialogTheme["textMuted"] }) {
+  const [frame, setFrame] = createSignal(0);
+  const interval = setInterval(() => {
+    setFrame((index) => (index + 1) % SPINNER_FRAMES.length);
+  }, 80).unref();
+
+  onCleanup(() => clearInterval(interval));
+
+  return (
+    <box flexDirection="row" gap={1}>
+      <text fg={props.color}>{SPINNER_FRAMES[frame()]}</text>
+      <text fg={props.color}>{props.text}</text>
+    </box>
+  );
+}
+
+function SupabaseSpinnerDialog(props: {
+  api: TuiPluginApi;
+  title: string;
+  status: string;
+  body?: string;
+  dismissible?: boolean;
+  size?: "medium" | "large" | "xlarge";
+  onClose: () => void;
+}): JSX.Element {
+  const theme = getDialogTheme(props.api);
+  const syntax = createMarkdownSyntax(theme);
+  props.api.ui.dialog.setSize(props.size ?? "medium");
+
+  return Object.assign(() => (
+    <box paddingLeft={2} paddingRight={2} gap={1} paddingBottom={1}>
+      <box flexDirection="row" justifyContent="space-between">
+        <text attributes={TextAttributes.BOLD} fg={theme.text}>
+          {props.title}
+        </text>
+        {props.dismissible ? (
+          <text fg={theme.textMuted} onMouseUp={props.onClose}>
+            esc
+          </text>
+        ) : (
+          <text fg={theme.textMuted}> </text>
+        )}
+      </box>
+      <box paddingTop={1} paddingBottom={props.body ? 0 : 1}>
+        <SpinnerLabel text={props.status} color={theme.textMuted} />
+      </box>
+      {props.body ? (
+        <box paddingBottom={props.dismissible ? 0 : 1}>
+          <markdown content={props.body} syntaxStyle={syntax} fg={theme.markdownText} bg={theme.backgroundPanel} />
+        </box>
+      ) : undefined}
+      {props.dismissible ? (
+        <box flexDirection="row" justifyContent="flex-end" paddingTop={1}>
+          <box paddingLeft={3} paddingRight={3} backgroundColor={theme.primary} onMouseUp={props.onClose}>
+            <text fg={theme.selectedListItemText}>Cancel</text>
+          </box>
+        </box>
+      ) : undefined}
+    </box>
+  ), { onClose: props.dismissible ? props.onClose : () => undefined });
 }
 
 function parseAuthStatus(instructions: string): AuthStatus {
@@ -400,10 +501,12 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       void retryPreflight();
     });
 
-    return props.api.ui.DialogAlert({
+    return SupabaseSpinnerDialog({
+      api: props.api,
       title: "Connect Supabase",
-      message: "Checking Supabase connection...",
-      onConfirm: () => closeDialog(true),
+      status: "Checking Supabase connection...",
+      body: "Let this run. It should only take a few seconds.",
+      onClose: () => undefined,
     });
   }
 
@@ -418,25 +521,36 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
   if (currentState.type === "authorizing") {
     if (!currentState.url) {
-    return props.api.ui.DialogAlert({
-      title: "Connect Supabase",
-      message: "Starting authorization...",
-      onConfirm: () => closeDialog(true),
-    });
+      return SupabaseSpinnerDialog({
+        api: props.api,
+        title: "Connect Supabase",
+        status: "Starting authorization...",
+        body: "Opening your browser. Let this run for a few seconds.",
+        dismissible: true,
+        onClose: () => closeDialog(true),
+      });
     }
 
-    return props.api.ui.DialogAlert({
+    return SupabaseSpinnerDialog({
+      api: props.api,
       title: "Connect to Supabase",
-      message: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nWaiting for authorization...`,
-      onConfirm: () => closeDialog(true),
+      status: "Waiting for browser authorization...",
+      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nLet this run after approval; it should only take a few seconds.`,
+      dismissible: true,
+      size: "large",
+      onClose: () => closeDialog(true),
     });
   }
 
   if (currentState.type === "waiting_callback") {
-    return props.api.ui.DialogAlert({
+    return SupabaseSpinnerDialog({
+      api: props.api,
       title: "Connect to Supabase",
-      message: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nWaiting for authorization...`,
-      onConfirm: () => closeDialog(true),
+      status: "Waiting for authorization...",
+      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nLet this run after approval; it should only take a few seconds.`,
+      dismissible: true,
+      size: "large",
+      onClose: () => closeDialog(true),
     });
   }
 

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -158,7 +158,7 @@ function SupabaseSpinnerDialog(props: {
       {props.dismissible ? (
         <box flexDirection="row" justifyContent="flex-end" paddingTop={1}>
           <box paddingLeft={3} paddingRight={3} backgroundColor={theme.primary} onMouseUp={props.onClose}>
-            <text fg={theme.selectedListItemText}>Cancel</text>
+            <text fg={theme.selectedListItemText}>Dismiss</text>
           </box>
         </box>
       ) : undefined}
@@ -408,7 +408,6 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
     if (nextState.type === "success") {
       if (lifecycle.dismissed) {
-        // User dismissed waiting dialog; stay silent
         return;
       }
       props.api.ui.dialog.replace(() =>
@@ -431,6 +430,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
   };
 
   const startOAuth = async () => {
+    lifecycle.dismissed = false;
     if (!lifecycle.chatSessionID) {
       lifecycle.chatSessionID = await ensureChatSession(props.api);
     }
@@ -440,9 +440,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       setState,
       onSuccess: () => {
         if (lifecycle.dismissed) {
-          props.api.ui.toast({
-            message: "Supabase connected",
-          });
+          props.api.ui.toast({ message: "Supabase connected" });
           return;
         }
 
@@ -525,7 +523,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
         api: props.api,
         title: "Connect Supabase",
         status: "Starting authorization...",
-        body: "Opening your browser. Let this run for a few seconds.",
+        body: "Opening your browser. You can close this dialog; authorization only completes if you approve in browser.",
         dismissible: true,
         onClose: () => closeDialog(true),
       });
@@ -535,7 +533,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       api: props.api,
       title: "Connect to Supabase",
       status: "Waiting for browser authorization...",
-      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nLet this run after approval; it should only take a few seconds.`,
+      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nYou can close this dialog; authorization only completes if you approve in browser.`,
       dismissible: true,
       size: "large",
       onClose: () => closeDialog(true),
@@ -547,7 +545,7 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
       api: props.api,
       title: "Connect to Supabase",
       status: "Waiting for authorization...",
-      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nLet this run after approval; it should only take a few seconds.`,
+      body: `Complete authorization in your browser.\n\nIf the browser did not open, visit:\n${currentState.url}\n\nYou can close this dialog; authorization only completes if you approve in browser.`,
       dismissible: true,
       size: "large",
       onClose: () => closeDialog(true),

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -44,6 +44,7 @@ function createDialogApi(overrides?: Record<string, unknown>) {
   const promptOps: Array<{ op: string; payload?: unknown }> = [];
   const sessionOps: Array<{ op: string; payload?: unknown }> = [];
   const routeOps: Array<{ op: string; name: string; params?: unknown }> = [];
+  const setSizes: string[] = [];
   let openCalls: string[] = [];
 
   const api = {
@@ -77,6 +78,9 @@ function createDialogApi(overrides?: Record<string, unknown>) {
         },
         clear: () => {
           cleared += 1;
+        },
+        setSize: (size: string) => {
+          setSizes.push(size);
         },
       },
     },
@@ -123,6 +127,7 @@ function createDialogApi(overrides?: Record<string, unknown>) {
       promptOps,
       sessionOps,
       routeOps,
+      setSizes,
       get cleared() {
         return cleared;
       },
@@ -147,6 +152,7 @@ function createDialogApi(overrides?: Record<string, unknown>) {
       promptOps: Array<{ op: string; payload?: unknown }>;
       sessionOps: Array<{ op: string; payload?: unknown }>;
       routeOps: Array<{ op: string; name: string; params?: unknown }>;
+      setSizes: string[];
       cleared: number;
       replaced: number;
       openCalls: string[];
@@ -181,6 +187,7 @@ test("tui plugin registers /supabase and opens a closable dialog", async () => {
   let replaceFactory: (() => unknown) | undefined;
   let cleared = 0;
   let usedCustomDialog = false;
+  const setSizes: string[] = [];
 
   await tuiModule.tui(
     {
@@ -203,6 +210,9 @@ test("tui plugin registers /supabase and opens a closable dialog", async () => {
           },
           clear: () => {
             cleared += 1;
+          },
+          setSize: (size: string) => {
+            setSizes.push(size);
           },
         },
         toast: () => {},
@@ -232,10 +242,9 @@ test("tui plugin registers /supabase and opens a closable dialog", async () => {
   expect(typeof replaceFactory).toBe("function");
 
   expect(typeof replaceFactory).toBe("function");
-  const rendered = replaceFactory?.() as { title?: string; message?: string };
-  expect(rendered).toMatchObject({
-    title: "Connect Supabase",
-  });
+  const rendered = replaceFactory?.();
+  expect(typeof rendered).toBe("function");
+  expect(setSizes).toEqual(["medium"]);
   expect(usedCustomDialog).toBe(false);
   expect(cleared).toBe(0);
 });
@@ -265,12 +274,15 @@ test("supabase dialog does not inject onboarding after waiting dialog was dismis
       toast: (input: { variant?: string; message: string }) => {
         api.__test.toasts.push(input);
       },
-      dialog: {
-        replace: (factory: () => unknown) => {
-          currentDialog = factory();
+        dialog: {
+          replace: (factory: () => unknown) => {
+            currentDialog = factory();
+          },
+          clear: () => undefined,
+          setSize: (size: string) => {
+            api.__test.setSizes.push(size);
+          },
         },
-        clear: () => undefined,
-      },
     },
     client: {
       app: {
@@ -311,8 +323,9 @@ test("supabase dialog does not inject onboarding after waiting dialog was dismis
   const authPromise = dialog.onConfirm?.();
   await new Promise((resolve) => setTimeout(resolve, 0));
 
-  expect(currentDialog).toMatchObject({ title: "Connect to Supabase" });
-  (currentDialog as { onConfirm?: () => void }).onConfirm?.();
+  expect(api.__test.setSizes).toContain("large");
+  expect(api.__test.dialogs).toHaveLength(0);
+  (currentDialog as { onClose?: () => void }).onClose?.();
   expect(lifecycle.dismissed).toBe(true);
 
   releaseCallback();
@@ -733,12 +746,13 @@ test("supabase dialog starts preflight only once while first check is pending", 
       DialogAlert: (input: unknown) => input,
       DialogConfirm: (input: unknown) => input,
       toast: (_input: { variant?: string; message: string }) => undefined,
-      dialog: {
-        replace: (factory: () => unknown) => {
-          currentDialog = factory();
+        dialog: {
+          replace: (factory: () => unknown) => {
+            currentDialog = factory();
+          },
+          clear: () => undefined,
+          setSize: () => undefined,
         },
-        clear: () => undefined,
-      },
     },
     client: {
       app: {
@@ -815,6 +829,7 @@ test("tui plugin reusing the original /supabase dialog factory should not start 
             replaceFactory = factory;
           },
           clear: () => {},
+          setSize: () => {},
         },
         toast: () => {},
       },
@@ -951,7 +966,7 @@ test("supabase dialog unknown state offers retry and continue", async () => {
   expect(typeof dialog.onCancel).toBe("function");
 });
 
-test("supabase dialog starts with built in checking alert", () => {
+test("supabase dialog starts with custom checking spinner dialog", () => {
   const api = createDialogApi();
   const dialog = SupabaseDialog({
     api: api as never,
@@ -959,11 +974,10 @@ test("supabase dialog starts with built in checking alert", () => {
     onClose: () => api.ui.dialog.clear(),
   });
 
-  expect(dialog).toMatchObject({
-    title: "Connect Supabase",
-  });
-  expect(api.__test.dialogAlerts).toHaveLength(1);
+  expect(typeof dialog).toBe("function");
+  expect(api.__test.dialogAlerts).toHaveLength(0);
   expect(api.__test.dialogs).toHaveLength(0);
+  expect(api.__test.setSizes).toEqual(["medium"]);
 });
 
 test("supabase dialog idle uses built in confirm dialog", () => {
@@ -983,7 +997,7 @@ test("supabase dialog idle uses built in confirm dialog", () => {
   expect(api.__test.dialogs).toHaveLength(0);
 });
 
-test("supabase dialog waiting states use built in alert dialog", () => {
+test("supabase dialog waiting states use custom spinner dialog", () => {
   const api = createDialogApi();
   const waiting = SupabaseDialog({
     api: api as never,
@@ -992,13 +1006,10 @@ test("supabase dialog waiting states use built in alert dialog", () => {
     initialState: { type: "waiting_callback", url: "https://example.com/auth" },
   });
 
-  expect(waiting).toMatchObject({
-    title: "Connect to Supabase",
-    message:
-      "Complete authorization in your browser.\n\nIf the browser did not open, visit:\nhttps://example.com/auth\n\nWaiting for authorization...",
-  });
-  expect(api.__test.dialogAlerts).toHaveLength(1);
+  expect(typeof waiting).toBe("function");
+  expect(api.__test.dialogAlerts).toHaveLength(0);
   expect(api.__test.dialogs).toHaveLength(0);
+  expect(api.__test.setSizes).toEqual(["large"]);
 });
 
 test("supabase auth flow enters waiting state before callback resolves", async () => {

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -172,7 +172,7 @@ test("supabase command exposes the expected slash metadata", () => {
     opened += 1;
   });
 
-  expect(command?.title).toBe("Connect Supabase");
+  expect(command?.title).toBe("Connect to Supabase");
   expect(command?.value).toBe("supabase.connect");
   expect(command?.slash).toEqual({ name: "supabase" });
 
@@ -1017,7 +1017,7 @@ test("supabase dialog idle uses built in confirm dialog", () => {
 
   expect(dialog).toMatchObject({
     title: "Connect your Supabase account",
-    message: "Opens your browser to authorize OpenCode to access your Supabase account.",
+    message: "Open your browser to authorize OpenCode to access your Supabase account.",
   });
   expect(api.__test.dialogConfirms).toHaveLength(1);
   expect(api.__test.dialogs).toHaveLength(0);

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -249,8 +249,9 @@ test("tui plugin registers /supabase and opens a closable dialog", async () => {
   expect(cleared).toBe(0);
 });
 
-test("supabase dialog does not inject onboarding after waiting dialog was dismissed", async () => {
+test("supabase dialog shows toast without onboarding after waiting dialog was dismissed", async () => {
   let currentDialog: unknown;
+  let currentDialogOnClose: (() => void) | undefined;
   let releaseCallback!: () => void;
 
   const api = createDialogApi({
@@ -274,15 +275,16 @@ test("supabase dialog does not inject onboarding after waiting dialog was dismis
       toast: (input: { variant?: string; message: string }) => {
         api.__test.toasts.push(input);
       },
-        dialog: {
-          replace: (factory: () => unknown) => {
-            currentDialog = factory();
-          },
-          clear: () => undefined,
-          setSize: (size: string) => {
-            api.__test.setSizes.push(size);
-          },
+      dialog: {
+        replace: (factory: () => unknown, onClose?: () => void) => {
+          currentDialog = factory();
+          currentDialogOnClose = onClose;
         },
+        clear: () => undefined,
+        setSize: (size: string) => {
+          api.__test.setSizes.push(size);
+        },
+      },
     },
     client: {
       app: {
@@ -325,18 +327,42 @@ test("supabase dialog does not inject onboarding after waiting dialog was dismis
 
   expect(api.__test.setSizes).toContain("large");
   expect(api.__test.dialogs).toHaveLength(0);
-  (currentDialog as { onClose?: () => void }).onClose?.();
+  expect(currentDialog).toBeDefined();
+  ((currentDialog as { onClose?: () => void }).onClose ?? currentDialogOnClose)?.();
   expect(lifecycle.dismissed).toBe(true);
 
   releaseCallback();
   await authPromise;
 
   expect(api.__test.sessionOps.filter((op) => op.op === "promptAsync")).toHaveLength(0);
-  expect(api.__test.toasts).toEqual([
-    {
-      message: "Supabase connected",
+  expect(api.__test.toasts).toEqual([{ message: "Supabase connected" }]);
+});
+
+test("supabase auth retry clears dismissed state", async () => {
+  const api = createDialogApi({
+    route: {
+      current: {
+        name: "session",
+        params: { sessionID: "session-current" },
+      },
+      navigate: () => undefined,
     },
-  ]);
+  });
+  const lifecycle = { closed: false, dismissed: true };
+
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: { type: "idle" },
+    lifecycle,
+  }) as { onConfirm?: () => Promise<void> };
+
+  await dialog.onConfirm?.();
+
+  expect(lifecycle.dismissed).toBe(false);
+  expect(api.__test.toasts).toEqual([]);
+  expect(api.__test.sessionOps.filter((op) => op.op === "promptAsync")).toHaveLength(1);
 });
 
 test("supabase dialog success closes without inserting an example prompt", async () => {


### PR DESCRIPTION
## Summary

- **Spinner auth dialog**: Replaced static `DialogAlert` screens with an animated braille spinner and markdown body for checking, authorizing, and waiting-for-callback states
- **OAuth dismiss semantics**: `Dismiss` closes only the dialog; browser approval can still complete auth and show the success toast. `Cancel`/`Abort` omitted because the current SDK OAuth callback cannot be reliably revoked
- **Connection flow polish**: Unified titles to "Connect to Supabase", imperative browser copy, "No action needed" preflight text, and shorter approval copy
- **Post-auth cleanup**: Simplified onboarding copy, success state uses single OK button (DialogAlert) instead of Cancel/Confirm

## Commits

- `d7c5219` feat(tui): add spinner auth dialog
- `44eb4ad` fix(tui): clarify OAuth dismiss
- `676e192` fix(tui): improve dialog wording consistency and copy
- `62883ba` chore: update changeset to reflect spinner dialog and OAuth dismiss

## Notes

- PR scoped to `opencode-supabase` plugin; no OpenCode core changes
- Dismiss behavior matches OpenCode's own `AutoMethod` pattern — callback continues after dialog closes
- Very short terminals may clip tall dialog content; OpenCode dialog shell positions at ~25% from top