### PR TITLE
Bundle Supabase agent skills

### DIFF
--- a/.changeset/bundle-supabase-skills.md
+++ b/.changeset/bundle-supabase-skills.md
@@ -1,0 +1,10 @@
+---
+"opencode-supabase": minor
+---
+
+Bundle Supabase agent skills as vendored files with configurable runtime registration
+
+- Vendor `supabase` and `supabase-postgres-best-practices` skill directories from `supabase/agent-skills`
+- Add `skills:sync` script to update vendored skills from upstream (defaults to latest default branch, accepts explicit commit/ref)
+- Register skill paths via plugin `config` hook; disable per-skill or entirely through plugin options
+- Add tests for skill resolution and path registration

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,5 +23,6 @@ Use this reference when implementing or reviewing authenticated Supabase API too
 
 - Do not replace `skills/` with a symlink or submodule.
 - Do not fetch skills during plugin startup, normal build, or release artifact generation.
-- Use `bun run skills:sync <commit-sha>` to update vendored skills.
+- Use `bun run skills:sync` to update vendored skills from the latest upstream default branch.
+- Use `bun run skills:sync <commit-sha-or-ref>` to sync a specific upstream ref.
 - Review skill diffs and `skills/.upstream.json` before release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,12 @@ For Supabase Management API work, prefer the markdownized docs:
 - https://supabase.com/docs/reference/api/introduction.md
 
 Use this reference when implementing or reviewing authenticated Supabase API tools.
+
+## Bundled Supabase Skills
+
+`skills/` contains real vendored files synced from `supabase/agent-skills` release tarballs.
+
+- Do not replace `skills/` with a symlink or submodule.
+- Do not fetch skills during plugin startup, normal build, or release artifact generation.
+- Use `bun run skills:sync` to update vendored skills.
+- Review skill diffs and `skills/.upstream.json` before release.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,9 +19,9 @@ Use this reference when implementing or reviewing authenticated Supabase API too
 
 ## Bundled Supabase Skills
 
-`skills/` contains real vendored files synced from `supabase/agent-skills` release tarballs.
+`skills/` contains real vendored files synced from `supabase/agent-skills` at a pinned commit.
 
 - Do not replace `skills/` with a symlink or submodule.
 - Do not fetch skills during plugin startup, normal build, or release artifact generation.
-- Use `bun run skills:sync` to update vendored skills.
+- Use `bun run skills:sync <commit-sha>` to update vendored skills.
 - Review skill diffs and `skills/.upstream.json` before release.

--- a/README.md
+++ b/README.md
@@ -59,10 +59,10 @@ Per-skill config is a partial override. Omitted skills stay enabled.
 
 ### Maintainer Skill Sync
 
-Bundled skills are vendored as real files under `skills/` from `supabase/agent-skills` GitHub release assets.
+Bundled skills are vendored as real files under `skills/` from `supabase/agent-skills`, pinned to an explicit upstream commit.
 
 ```bash
-bun run skills:sync
+bun run skills:sync <commit-sha>
 bun run typecheck
 bun test
 bun run verify:pack

--- a/README.md
+++ b/README.md
@@ -59,10 +59,11 @@ Per-skill config is a partial override. Omitted skills stay enabled.
 
 ### Maintainer Skill Sync
 
-Bundled skills are vendored as real files under `skills/` from `supabase/agent-skills`, pinned to an explicit upstream commit.
+Bundled skills are vendored as real files under `skills/` from `supabase/agent-skills`, pinned to an exact upstream commit in `skills/.upstream.json`.
 
 ```bash
-bun run skills:sync <commit-sha>
+bun run skills:sync
+# or: bun run skills:sync <commit-sha-or-ref>
 bun run typecheck
 bun test
 bun run verify:pack

--- a/README.md
+++ b/README.md
@@ -20,6 +20,56 @@ Launch `opencode` in your project, then run:
 
 Connect your account and ask your agent about Supabase capabilities.
 
+## Bundled Supabase Skills
+
+`opencode-supabase` ships the official Supabase agent skills by default:
+
+- `supabase`
+- `supabase-postgres-best-practices`
+
+No separate `skills` CLI setup is required. Installing the plugin makes these skills available to OpenCode through the plugin server config hook.
+
+### Disable Bundled Skills
+
+If you want Supabase tools without bundled skills, disable them in plugin options:
+
+```json
+{
+  "plugin": [
+    ["opencode-supabase", { "skills": false }]
+  ]
+}
+```
+
+### Select Individual Skills
+
+Per-skill config is a partial override. Omitted skills stay enabled.
+
+```json
+{
+  "plugin": [
+    ["opencode-supabase", {
+      "skills": {
+        "supabase-postgres-best-practices": false
+      }
+    }]
+  ]
+}
+```
+
+### Maintainer Skill Sync
+
+Bundled skills are vendored as real files under `skills/` from `supabase/agent-skills` GitHub release assets.
+
+```bash
+bun run skills:sync
+bun run typecheck
+bun test
+bun run verify:pack
+```
+
+Review the generated diff before releasing.
+
 ## OAuth Callback Contract
 
 Plugin uses fixed localhost callback window for browser auth:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Connect your account and ask your agent about Supabase capabilities.
 
 ## Bundled Supabase Skills
 
-`opencode-supabase` ships the official Supabase agent skills by default:
+`opencode-supabase` ships the official [Supabase agent skills](https://github.com/supabase/agent-skills) by default:
 
 - `supabase`
 - `supabase-postgres-best-practices`
@@ -43,7 +43,7 @@ If you want Supabase tools without bundled skills, disable them in plugin option
 
 ### Select Individual Skills
 
-Per-skill config is a partial override. Omitted skills stay enabled.
+Set a bundled skill name to `false` to disable only that skill. Omitted skills stay enabled. Unknown keys are ignored with a warning.
 
 ```json
 {

--- a/docs/2026-05-04-1424-agent-skills-plan.md
+++ b/docs/2026-05-04-1424-agent-skills-plan.md
@@ -1,0 +1,810 @@
+# Agent Skills Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bundle Supabase agent skills with `opencode-supabase`, auto-load them by default, and give users simple opt-out and per-skill selection.
+
+**Architecture:** Vendor skill files under repo-local `skills/`, register individual skill directories through the server plugin `config` hook, and keep updates deterministic through a manual sync script. No runtime clone, no build-time fetch, and no hidden release-time fetch.
+
+**Tech Stack:** Bun, TypeScript, OpenCode plugin server config hook, GitHub Release assets from `supabase/agent-skills`, existing `bun test` test suite.
+
+---
+
+## File Structure
+
+- `skills/.upstream.json` tracks source release metadata for vendored skills.
+- `skills/supabase/` contains the vendored broad Supabase skill.
+- `skills/supabase-postgres-best-practices/` contains the vendored Postgres best-practices skill.
+- `scripts/sync-agent-skills.ts` downloads release tarballs and replaces managed skill directories.
+- `src/server/skills.ts` resolves plugin options and registers selected skill directories.
+- `src/server/index.ts` wires the new `config` hook into the existing plugin server export.
+- `test/server-skills.test.ts` verifies option semantics and path registration behavior.
+- `package.json` includes `skills/` in published files and adds `skills:sync`.
+- `README.md` documents bundled skills, opt-out, per-skill config, and maintainer sync.
+- `AGENTS.md` documents that `skills/` must remain real vendored files.
+
+## Task 1: Add Initial Skill Provenance File
+
+**Files:**
+- Create: `skills/.upstream.json`
+
+- [ ] **Step 1: Create `skills/.upstream.json`**
+
+Use this exact content:
+
+```json
+{
+  "source_repo": "supabase/agent-skills",
+  "source_release": null,
+  "source_version": null,
+  "source_commit": null,
+  "synced_at": null,
+  "managed_paths": [
+    "skills/supabase",
+    "skills/supabase-postgres-best-practices"
+  ],
+  "assets": [
+    "supabase.tar.gz",
+    "supabase-postgres-best-practices.tar.gz"
+  ]
+}
+```
+
+- [ ] **Step 2: Verify directory file is readable**
+
+Run:
+
+```bash
+bun -e 'const data = await Bun.file("skills/.upstream.json").json(); console.log(data.source_repo)'
+```
+
+Expected output:
+
+```text
+supabase/agent-skills
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/.upstream.json
+git commit -m "feat: track bundled skill provenance"
+```
+
+## Task 2: Add Manual Skill Sync Script
+
+**Files:**
+- Create: `scripts/sync-agent-skills.ts`
+- Modify: `package.json`
+
+- [ ] **Step 1: Add failing smoke test command for missing script**
+
+Run:
+
+```bash
+bun run skills:sync --help
+```
+
+Expected before implementation:
+
+```text
+error: Script not found "skills:sync"
+```
+
+- [ ] **Step 2: Create `scripts/sync-agent-skills.ts`**
+
+Use this implementation:
+
+```ts
+import { $ } from "bun";
+
+const SOURCE_REPO = "supabase/agent-skills";
+const SKILLS_DIR = "skills";
+const MANAGED_SKILLS = ["supabase", "supabase-postgres-best-practices"] as const;
+const ASSETS = MANAGED_SKILLS.map((skill) => `${skill}.tar.gz`);
+
+async function commandText(strings: TemplateStringsArray, ...values: string[]) {
+  return (await $(strings, ...values).text()).trim();
+}
+
+function usage() {
+  return `Usage: bun run skills:sync [release-tag]\n\nIf release-tag is omitted, the latest ${SOURCE_REPO} release is used.`;
+}
+
+async function resolveRelease(inputTag: string | undefined) {
+  const tag = inputTag ?? (await commandText`gh release view --repo ${SOURCE_REPO} --json tagName --jq .tagName`);
+  const version = tag.startsWith("v") ? tag.slice(1) : tag;
+  const commit = await commandText`gh release view ${tag} --repo ${SOURCE_REPO} --json targetCommitish --jq .targetCommitish`;
+  return { tag, version, commit };
+}
+
+async function main() {
+  const arg = Bun.argv[2];
+  if (arg === "--help" || arg === "-h") {
+    console.log(usage());
+    return;
+  }
+
+  const release = await resolveRelease(arg);
+  const tmp = await commandText`mktemp -d`;
+
+  try {
+    await $`mkdir -p ${SKILLS_DIR}`;
+    await $`gh release download ${release.tag} --repo ${SOURCE_REPO} --dir ${tmp} --pattern ${ASSETS[0]} --pattern ${ASSETS[1]}`;
+
+    for (const skill of MANAGED_SKILLS) {
+      await $`rm -rf ${SKILLS_DIR}/${skill}`;
+      await $`tar -xzf ${tmp}/${skill}.tar.gz -C ${SKILLS_DIR}`;
+    }
+
+    const metadata = {
+      source_repo: SOURCE_REPO,
+      source_release: release.tag,
+      source_version: release.version,
+      source_commit: release.commit,
+      synced_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+      managed_paths: MANAGED_SKILLS.map((skill) => `${SKILLS_DIR}/${skill}`),
+      assets: ASSETS,
+    };
+
+    await Bun.write(`${SKILLS_DIR}/.upstream.json`, `${JSON.stringify(metadata, null, 2)}\n`);
+    console.log(`Synced ${SOURCE_REPO} ${release.tag} into ${SKILLS_DIR}/`);
+  } finally {
+    await $`rm -rf ${tmp}`;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});
+```
+
+- [ ] **Step 3: Add package script**
+
+Modify `package.json` scripts to include:
+
+```json
+"skills:sync": "bun scripts/sync-agent-skills.ts"
+```
+
+- [ ] **Step 4: Verify help output**
+
+Run:
+
+```bash
+bun run skills:sync --help
+```
+
+Expected output includes:
+
+```text
+Usage: bun run skills:sync [release-tag]
+```
+
+- [ ] **Step 5: Run sync**
+
+Run:
+
+```bash
+bun run skills:sync
+```
+
+Expected result:
+
+- `skills/supabase/SKILL.md` exists.
+- `skills/supabase-postgres-best-practices/SKILL.md` exists.
+- `skills/.upstream.json` has non-null `source_release`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add package.json scripts/sync-agent-skills.ts skills/
+git commit -m "feat: sync bundled Supabase skills"
+```
+
+## Task 3: Include Vendored Skills In Published Package
+
+**Files:**
+- Modify: `package.json`
+- Check: `.npmignore`
+
+- [ ] **Step 1: Update package files list**
+
+Ensure `package.json` includes `skills/` in `files`:
+
+```json
+"files": [
+  "src/",
+  "skills/",
+  "index.ts",
+  "README.md"
+]
+```
+
+- [ ] **Step 2: Check `.npmignore`**
+
+If `.npmignore` contains a rule that excludes `skills/`, remove that rule or add an allow rule:
+
+```text
+!skills/
+!skills/**
+```
+
+- [ ] **Step 3: Verify package contents**
+
+Run:
+
+```bash
+bun run verify:pack
+```
+
+Expected output includes:
+
+```text
+skills/.upstream.json
+skills/supabase/SKILL.md
+skills/supabase-postgres-best-practices/SKILL.md
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json .npmignore
+git commit -m "feat: publish bundled Supabase skills"
+```
+
+## Task 4: Add Skill Option Resolver And Path Registration
+
+**Files:**
+- Create: `src/server/skills.ts`
+- Create: `test/server-skills.test.ts`
+
+- [ ] **Step 1: Write resolver tests**
+
+Create `test/server-skills.test.ts`:
+
+```ts
+import { describe, expect, test } from "bun:test";
+import {
+  resolveEnabledSupabaseSkills,
+  registerSupabaseSkillPaths,
+} from "../src/server/skills.ts";
+
+describe("resolveEnabledSupabaseSkills", () => {
+  test("enables all bundled skills by default", () => {
+    expect(resolveEnabledSupabaseSkills(undefined)).toEqual([
+      "supabase",
+      "supabase-postgres-best-practices",
+    ]);
+  });
+
+  test("disables all skills when skills is false", () => {
+    expect(resolveEnabledSupabaseSkills({ skills: false })).toEqual([]);
+  });
+
+  test("keeps omitted skill keys enabled", () => {
+    expect(resolveEnabledSupabaseSkills({ skills: { "supabase-postgres-best-practices": false } })).toEqual([
+      "supabase",
+    ]);
+  });
+
+  test("warns and ignores unknown skill keys", () => {
+    const warnings: unknown[] = [];
+    expect(resolveEnabledSupabaseSkills({ skills: { typo: false } }, { warn: (_message, data) => warnings.push(data) })).toEqual([
+      "supabase",
+      "supabase-postgres-best-practices",
+    ]);
+    expect(warnings).toHaveLength(1);
+  });
+});
+
+describe("registerSupabaseSkillPaths", () => {
+  test("adds selected skill directories", () => {
+    const config: { skills?: { paths?: string[] } } = {};
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: () => true,
+    });
+    expect(config.skills?.paths).toEqual([
+      "/plugin/skills/supabase",
+      "/plugin/skills/supabase-postgres-best-practices",
+    ]);
+  });
+
+  test("does not add duplicate paths", () => {
+    const config = { skills: { paths: ["/plugin/skills/supabase"] } };
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: () => true,
+    });
+    expect(config.skills.paths).toEqual([
+      "/plugin/skills/supabase",
+      "/plugin/skills/supabase-postgres-best-practices",
+    ]);
+  });
+
+  test("warns and skips missing directories", () => {
+    const warnings: unknown[] = [];
+    const config: { skills?: { paths?: string[] } } = {};
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: (path) => !path.endsWith("postgres-best-practices"),
+      warn: (_message, data) => warnings.push(data),
+    });
+    expect(config.skills?.paths).toEqual(["/plugin/skills/supabase"]);
+    expect(warnings).toHaveLength(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run:
+
+```bash
+bun test test/server-skills.test.ts
+```
+
+Expected before implementation:
+
+```text
+Cannot find module '../src/server/skills.ts'
+```
+
+- [ ] **Step 3: Create `src/server/skills.ts`**
+
+Use this implementation:
+
+```ts
+import fs from "node:fs";
+import path from "node:path";
+
+export const BUNDLED_SUPABASE_SKILLS = [
+  "supabase",
+  "supabase-postgres-best-practices",
+] as const;
+
+export type BundledSupabaseSkill = (typeof BUNDLED_SUPABASE_SKILLS)[number];
+
+type Warn = (message: string, data?: unknown) => void;
+
+type ResolverDeps = {
+  warn?: Warn;
+};
+
+type RegisterDeps = ResolverDeps & {
+  skillsRoot?: string;
+  exists?: (path: string) => boolean;
+};
+
+type ConfigWithSkills = {
+  skills?: {
+    paths?: string[];
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function pluginSkillsOption(options: unknown) {
+  if (!isRecord(options) || !("skills" in options)) return true;
+  return options.skills;
+}
+
+export function resolveEnabledSupabaseSkills(options: unknown, deps: ResolverDeps = {}) {
+  const value = pluginSkillsOption(options);
+  if (value === false) return [];
+  if (value === true || value === undefined) return [...BUNDLED_SUPABASE_SKILLS];
+
+  if (!isRecord(value)) {
+    deps.warn?.("invalid Supabase skills option; loading bundled skills", { value });
+    return [...BUNDLED_SUPABASE_SKILLS];
+  }
+
+  const known = new Set<string>(BUNDLED_SUPABASE_SKILLS);
+  for (const key of Object.keys(value)) {
+    if (!known.has(key)) {
+      deps.warn?.("unknown Supabase bundled skill option ignored", { skill: key });
+    }
+  }
+
+  return BUNDLED_SUPABASE_SKILLS.filter((skill) => value[skill] !== false);
+}
+
+export function defaultSkillsRoot() {
+  return path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../skills");
+}
+
+export function registerSupabaseSkillPaths(
+  config: ConfigWithSkills,
+  options: unknown,
+  deps: RegisterDeps = {},
+) {
+  const skillsRoot = deps.skillsRoot ?? defaultSkillsRoot();
+  const exists = deps.exists ?? fs.existsSync;
+  const enabled = resolveEnabledSupabaseSkills(options, deps);
+
+  config.skills = config.skills ?? {};
+  config.skills.paths = config.skills.paths ?? [];
+
+  for (const skill of enabled) {
+    const skillPath = path.join(skillsRoot, skill);
+    if (!exists(skillPath)) {
+      deps.warn?.("bundled Supabase skill directory not found", { skill, path: skillPath });
+      continue;
+    }
+    if (!config.skills.paths.includes(skillPath)) {
+      config.skills.paths.push(skillPath);
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run focused tests**
+
+Run:
+
+```bash
+bun test test/server-skills.test.ts
+```
+
+Expected:
+
+```text
+pass
+```
+
+- [ ] **Step 5: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected:
+
+```text
+no TypeScript errors
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/server/skills.ts test/server-skills.test.ts
+git commit -m "feat: resolve bundled Supabase skills"
+```
+
+## Task 5: Wire OpenCode Config Hook
+
+**Files:**
+- Modify: `src/server/index.ts`
+
+- [ ] **Step 1: Modify server plugin to register skill paths**
+
+Update `src/server/index.ts` to import and call the helper:
+
+```ts
+import type { Plugin } from "@opencode-ai/plugin";
+
+import { createServerLogWriter, createSupabaseLogger } from "../shared/log.ts";
+import { createSupabaseAuth } from "./auth.ts";
+import { registerSupabaseSkillPaths } from "./skills.ts";
+import { createSupabaseTools } from "./tools.ts";
+
+const server: Plugin = async (input, options) => {
+  const logger = createSupabaseLogger({
+    write: createServerLogWriter(input.client),
+  });
+
+  return {
+    config: async (config) => {
+      registerSupabaseSkillPaths(config, options, {
+        warn: (message, data) => logger.warn(message, data as Record<string, unknown>),
+      });
+    },
+    auth: createSupabaseAuth(input, options, { logger }),
+    tool: createSupabaseTools(input, options, { logger }),
+  };
+};
+
+export default { id: "supabase", server };
+```
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected:
+
+```text
+no TypeScript errors
+```
+
+- [ ] **Step 3: Run tests**
+
+Run:
+
+```bash
+bun test
+```
+
+Expected:
+
+```text
+all tests pass
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/server/index.ts
+git commit -m "feat: auto-load bundled Supabase skills"
+```
+
+## Task 6: Document User And Maintainer Behavior
+
+**Files:**
+- Modify: `README.md`
+- Modify: `AGENTS.md`
+
+- [ ] **Step 1: Add README section for bundled skills**
+
+Add this section near install/configuration docs:
+
+```md
+## Bundled Supabase Skills
+
+`opencode-supabase` ships the official Supabase agent skills by default:
+
+- `supabase`
+- `supabase-postgres-best-practices`
+
+No separate `skills` CLI setup is required. Installing the plugin makes these skills available to OpenCode through the plugin server config hook.
+
+### Disable Bundled Skills
+
+If you want Supabase tools without bundled skills, disable them in plugin options:
+
+```json
+{
+  "plugin": [
+    ["opencode-supabase", { "skills": false }]
+  ]
+}
+```
+
+### Select Individual Skills
+
+Per-skill config is a partial override. Omitted skills stay enabled.
+
+```json
+{
+  "plugin": [
+    ["opencode-supabase", {
+      "skills": {
+        "supabase-postgres-best-practices": false
+      }
+    }]
+  ]
+}
+```
+
+### Maintainer Skill Sync
+
+Bundled skills are vendored as real files under `skills/` from `supabase/agent-skills` GitHub release assets.
+
+```bash
+bun run skills:sync
+bun run typecheck
+bun test
+bun run verify:pack
+```
+
+Review the generated diff before releasing.
+```
+
+- [ ] **Step 2: Add AGENTS.md maintainer rule**
+
+Add this section:
+
+```md
+## Bundled Supabase Skills
+
+`skills/` contains real vendored files synced from `supabase/agent-skills` release tarballs.
+
+- Do not replace `skills/` with a symlink or submodule.
+- Do not fetch skills during plugin startup, normal build, or release artifact generation.
+- Use `bun run skills:sync` to update vendored skills.
+- Review skill diffs and `skills/.upstream.json` before release.
+```
+
+- [ ] **Step 3: Verify docs mention opt-out**
+
+Run:
+
+```bash
+bun -e 'const text = await Bun.file("README.md").text(); if (!text.includes("skills\": false")) process.exit(1); console.log("ok")'
+```
+
+Expected output:
+
+```text
+ok
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md AGENTS.md
+git commit -m "docs: document bundled Supabase skills"
+```
+
+## Task 7: Create Follow-Up Issue For Automatic Sync PRs
+
+**Files:**
+- No source files required.
+
+- [ ] **Step 1: Create issue body file in temporary location**
+
+Run:
+
+```bash
+cat > /tmp/opencode-supabase-sync-skills-issue.md <<'EOF'
+## Goal
+
+Port the automatic sync PR workflow from `supabase-community/supabase-plugin` so `opencode-supabase` can poll `supabase/agent-skills` releases and open PRs when vendored skills are stale.
+
+## Current MVP
+
+`opencode-supabase` vendors real skill files under `skills/` and updates them manually with `bun run skills:sync`.
+
+## Reference
+
+- `/home/jumski/Code/supabase-community/supabase-plugin/.github/workflows/sync-agent-skills.yml`
+- `/home/jumski/Code/supabase-community/supabase-plugin/skills/.upstream.json`
+
+## Desired Workflow
+
+- Trigger weekly and via `workflow_dispatch`.
+- Resolve latest `supabase/agent-skills` GitHub release.
+- Compare release tag against `skills/.upstream.json`.
+- Download `supabase.tar.gz`.
+- Download `supabase-postgres-best-practices.tar.gz`.
+- Replace `skills/supabase`.
+- Replace `skills/supabase-postgres-best-practices`.
+- Update `skills/.upstream.json`.
+- Open PR with `peter-evans/create-pull-request`.
+
+## Acceptance Criteria
+
+- No runtime clone/install.
+- No hidden build-time fetch.
+- Sync PR contains real file diffs.
+- Release remains deterministic.
+EOF
+```
+
+- [ ] **Step 2: Create GitHub issue**
+
+Run:
+
+```bash
+gh issue create --title "Port automatic agent-skills sync workflow" --body-file /tmp/opencode-supabase-sync-skills-issue.md
+```
+
+Expected output:
+
+```text
+https://github.com/jumski/opencode-supabase/issues/<number>
+```
+
+## Task 8: Final Verification
+
+**Files:**
+- Verify all changed files.
+
+- [ ] **Step 1: Run typecheck**
+
+```bash
+bun run typecheck
+```
+
+Expected:
+
+```text
+no TypeScript errors
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+bun test
+```
+
+Expected:
+
+```text
+all tests pass
+```
+
+- [ ] **Step 3: Verify package contents**
+
+```bash
+bun run verify:pack
+```
+
+Expected output includes:
+
+```text
+skills/.upstream.json
+skills/supabase/SKILL.md
+skills/supabase-postgres-best-practices/SKILL.md
+```
+
+- [ ] **Step 4: Manual OpenCode smoke test**
+
+From a consumer repo, install and start OpenCode:
+
+```bash
+opencode plugin ../../opencode-supabase
+opencode
+```
+
+Expected:
+
+- `supabase` skill is listed as available.
+- `supabase-postgres-best-practices` skill is listed as available.
+- `/supabase` auth flow and tools still load.
+
+- [ ] **Step 5: Manual opt-out smoke test**
+
+Configure plugin options with:
+
+```json
+{
+  "plugin": [
+    ["../../opencode-supabase", { "skills": false }]
+  ]
+}
+```
+
+Restart OpenCode.
+
+Expected:
+
+- Bundled Supabase skill paths are not registered by the plugin.
+- `/supabase` auth flow and tools still load.
+
+- [ ] **Step 6: Commit final verification/docs if changed**
+
+```bash
+git status --short
+git add .
+git commit -m "test: verify bundled Supabase skills"
+```
+
+## Acceptance Criteria
+
+- Fresh plugin install auto-loads bundled Supabase skills.
+- Users can disable all bundled skills with `skills: false`.
+- Users can disable individual bundled skills with object-form `skills` config.
+- Omitted per-skill keys remain enabled.
+- Unknown skill keys log warnings and do not break plugin startup.
+- Missing bundled skill directories log warnings and do not break tools/auth.
+- Package includes vendored skill files.
+- User install has no runtime network, git, or setup tool dependency for skills.
+- Manual maintainer sync exists and updates `skills/.upstream.json`.
+- GitHub issue tracks future automatic sync PR workflow.
+
+## Self-Review
+
+- Spec coverage: covered default auto-load, opt-out, per-skill config, manual sync, package inclusion, docs, and future automation issue.
+- Placeholder scan: no unresolved TBD/TODO placeholders.
+- Type consistency: plan consistently uses `skills`, `registerSupabaseSkillPaths`, `resolveEnabledSupabaseSkills`, `skills/.upstream.json`, and the two bundled skill names.

--- a/docs/2026-05-04-1424-agent-skills-plan.md
+++ b/docs/2026-05-04-1424-agent-skills-plan.md
@@ -6,7 +6,7 @@
 
 **Architecture:** Vendor skill files under repo-local `skills/`, register individual skill directories through the server plugin `config` hook, and keep updates deterministic through a manual sync script. No runtime clone, no build-time fetch, and no hidden release-time fetch.
 
-**Tech Stack:** Bun, TypeScript, OpenCode plugin server config hook, GitHub Release assets from `supabase/agent-skills`, existing `bun test` test suite.
+**Tech Stack:** Bun, TypeScript, OpenCode plugin server config hook, GitHub tarball snapshots from `supabase/agent-skills`, existing `bun test` test suite.
 
 ---
 
@@ -15,7 +15,7 @@
 - `skills/.upstream.json` tracks source release metadata for vendored skills.
 - `skills/supabase/` contains the vendored broad Supabase skill.
 - `skills/supabase-postgres-best-practices/` contains the vendored Postgres best-practices skill.
-- `scripts/sync-agent-skills.ts` downloads release tarballs and replaces managed skill directories.
+- `scripts/sync-agent-skills.ts` downloads commit tarballs and replaces managed skill directories.
 - `src/server/skills.ts` resolves plugin options and registers selected skill directories.
 - `src/server/index.ts` wires the new `config` hook into the existing plugin server export.
 - `test/server-skills.test.ts` verifies option semantics and path registration behavior.

--- a/docs/2026-05-04-1424-agent-skills-spec.md
+++ b/docs/2026-05-04-1424-agent-skills-spec.md
@@ -1,0 +1,201 @@
+# Agent Skills Feature Spec
+
+## Goal
+
+Ship Supabase agent skills with `opencode-supabase` so a normal plugin install gives users both Supabase tools and Supabase-specific agent guidance without any extra setup step.
+
+## Background
+
+`supabase/agent-skills` publishes official Supabase skills that teach agents how to work with Supabase safely and correctly. The current manual install path, such as `npx skills add supabase/agent-skills`, is separate from installing `opencode-supabase`. That creates a gap: users may install the plugin and get Supabase auth/tools, but miss the guidance layer that improves correctness around RLS, Auth, migrations, CLI usage, and Postgres best practices.
+
+OpenCode plugins can register extra skill directories by mutating `config.skills.paths` in the plugin server `config` hook. OpenCode treats each configured path as a directory root and scans it recursively for `**/SKILL.md`. This means `opencode-supabase` can register either a parent `skills/` directory or individual skill directories.
+
+## Decisions
+
+The MVP will vendor Supabase skills as real files inside this repository under `skills/` and auto-load them by default.
+
+Runtime cloning is out of scope. Build-time or release-time hidden fetching is also out of scope. Skill updates should happen as reviewed source changes, not as hidden package-generation side effects.
+
+The initial sync model is a manual reusable script. A future GitHub Action can reuse the same repo shape and metadata model to open automatic sync PRs.
+
+## User Experience
+
+Default install should require no skill-specific decision from the user. Installing `opencode-supabase` should enable:
+
+- Supabase OAuth and tools.
+- Bundled `supabase` skill.
+- Bundled `supabase-postgres-best-practices` skill.
+
+Users who do not want bundled skills can disable them with plugin options. Tools and `/supabase` auth must continue to work when skills are disabled.
+
+Disable all bundled skills:
+
+```json
+{
+  "plugin": [
+    ["opencode-supabase", { "skills": false }]
+  ]
+}
+```
+
+Disable one bundled skill:
+
+```json
+{
+  "plugin": [
+    ["opencode-supabase", {
+      "skills": {
+        "supabase-postgres-best-practices": false
+      }
+    }]
+  ]
+}
+```
+
+Load only the broad Supabase skill:
+
+```json
+{
+  "plugin": [
+    ["opencode-supabase", {
+      "skills": {
+        "supabase": true,
+        "supabase-postgres-best-practices": false
+      }
+    }]
+  ]
+}
+```
+
+## Config Semantics
+
+Supported plugin option shapes:
+
+```ts
+type SupabasePluginOptions = {
+  skills?: boolean | Partial<Record<"supabase" | "supabase-postgres-best-practices", boolean>>;
+};
+```
+
+Rules:
+
+- Missing `skills` means all bundled skills are enabled.
+- `skills: true` means all bundled skills are enabled.
+- `skills: false` means no bundled skills are enabled.
+- Object form is a partial override.
+- Omitted keys in object form stay enabled.
+- Unknown keys are logged as warnings and ignored.
+- Missing bundled skill directories are logged as warnings and skipped.
+- Duplicate path entries are not added to `config.skills.paths`.
+
+## OpenCode Integration
+
+The server plugin should add a `config` hook in `src/server/index.ts`. The hook should call a small helper that mutates `config.skills.paths` synchronously.
+
+Use individual skill directories instead of the parent `skills/` directory:
+
+```text
+skills/supabase
+skills/supabase-postgres-best-practices
+```
+
+This makes per-skill enablement simple and avoids loading disabled skills from a shared parent directory.
+
+The hook must not perform network, git, or async filesystem setup work. It should only resolve local package paths, check selected skills, and push paths into the live config object.
+
+## Vendored Skill Source
+
+The source of truth for skill content remains `supabase/agent-skills`. This repository consumes release assets from that producer repo:
+
+- `supabase.tar.gz`
+- `supabase-postgres-best-practices.tar.gz`
+
+Vendored skills live under:
+
+```text
+skills/supabase
+skills/supabase-postgres-best-practices
+```
+
+Provenance is tracked in:
+
+```text
+skills/.upstream.json
+```
+
+Initial metadata shape:
+
+```json
+{
+  "source_repo": "supabase/agent-skills",
+  "source_release": null,
+  "source_version": null,
+  "source_commit": null,
+  "synced_at": null,
+  "managed_paths": [
+    "skills/supabase",
+    "skills/supabase-postgres-best-practices"
+  ],
+  "assets": [
+    "supabase.tar.gz",
+    "supabase-postgres-best-practices.tar.gz"
+  ]
+}
+```
+
+## Maintainer Workflow
+
+For MVP, maintainers update skills manually:
+
+```bash
+bun run skills:sync
+bun run typecheck
+bun test
+bun run verify:pack
+```
+
+The sync script should download the latest `supabase/agent-skills` release by default. It should also support an explicit release tag:
+
+```bash
+bun run skills:sync -- v0.1.0
+```
+
+After syncing, maintainers review the generated file diff and commit it as normal source. Releases package the already-vendored files from git.
+
+## Future Automation
+
+Create a GitHub issue for later automation. The issue should document how to port the automatic workflow from `supabase-community/supabase-plugin`.
+
+Future automated workflow should:
+
+- Run on a schedule and via `workflow_dispatch`.
+- Resolve the latest `supabase/agent-skills` release.
+- Compare it against `skills/.upstream.json`.
+- Download both skill tarballs.
+- Replace the vendored skill directories.
+- Update `.upstream.json`.
+- Open a PR with real file diffs.
+
+The future workflow should not fetch skills during normal build, package, plugin startup, or user install.
+
+## Non-Goals
+
+- Runtime clone or install of `supabase/agent-skills`.
+- User-facing setup tool for skills.
+- Automatic update command in the plugin.
+- Build-time network fetch.
+- Release-time hidden fetch.
+- Skill version manager UI.
+- Auto-detection and reconciliation of globally installed duplicate skills.
+
+## Acceptance Criteria
+
+- Fresh plugin install auto-loads bundled Supabase skills.
+- Users can disable all bundled skills.
+- Users can disable individual bundled skills.
+- Disabling skills does not disable OAuth, `/supabase`, or Supabase tools.
+- Skills are vendored as real files, not symlinks or submodules.
+- Published package includes `skills/**` and `skills/.upstream.json`.
+- No runtime network or git dependency is introduced for users.
+- Maintainer can sync skills manually and review diffs before release.
+- Future automatic sync is tracked in a GitHub issue.

--- a/docs/2026-05-04-1424-agent-skills-spec.md
+++ b/docs/2026-05-04-1424-agent-skills-spec.md
@@ -105,10 +105,7 @@ The hook must not perform network, git, or async filesystem setup work. It shoul
 
 ## Vendored Skill Source
 
-The source of truth for skill content remains `supabase/agent-skills`. This repository consumes release assets from that producer repo:
-
-- `supabase.tar.gz`
-- `supabase-postgres-best-practices.tar.gz`
+The source of truth for skill content remains `supabase/agent-skills`. This repository consumes tarball snapshots for a resolved upstream commit from that producer repo.
 
 Vendored skills live under:
 
@@ -131,15 +128,14 @@ Initial metadata shape:
   "source_release": null,
   "source_version": null,
   "source_commit": null,
+  "source_ref": null,
+  "source_ref_type": null,
   "synced_at": null,
   "managed_paths": [
     "skills/supabase",
     "skills/supabase-postgres-best-practices"
   ],
-  "assets": [
-    "supabase.tar.gz",
-    "supabase-postgres-best-practices.tar.gz"
-  ]
+  "assets": null
 }
 ```
 
@@ -154,10 +150,10 @@ bun test
 bun run verify:pack
 ```
 
-The sync script should download the latest `supabase/agent-skills` release by default. It should also support an explicit release tag:
+The sync script should download the latest `supabase/agent-skills` default-branch commit by default. It should also support an explicit commit/ref:
 
 ```bash
-bun run skills:sync -- v0.1.0
+bun run skills:sync -- 4bb13d858d19f1f848505a66f46fc9603fdcde95
 ```
 
 After syncing, maintainers review the generated file diff and commit it as normal source. Releases package the already-vendored files from git.
@@ -169,9 +165,9 @@ Create a GitHub issue for later automation. The issue should document how to por
 Future automated workflow should:
 
 - Run on a schedule and via `workflow_dispatch`.
-- Resolve the latest `supabase/agent-skills` release.
+- Resolve the latest `supabase/agent-skills` default-branch commit.
 - Compare it against `skills/.upstream.json`.
-- Download both skill tarballs.
+- Download the upstream repository tarball at the resolved commit.
 - Replace the vendored skill directories.
 - Update `.upstream.json`.
 - Open a PR with real file diffs.

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   },
   "files": [
     "src/",
+    "skills/",
     "index.ts",
     "README.md"
   ],
@@ -25,6 +26,7 @@
   "scripts": {
     "lint": "biome check .",
     "verify:pack": "npm pack --dry-run",
+    "skills:sync": "bun scripts/sync-agent-skills.ts",
     "typecheck": "bunx tsc --noEmit",
     "test": "bun test --preload @opentui/solid/preload",
     "changeset": "changeset",

--- a/scripts/sync-agent-skills.ts
+++ b/scripts/sync-agent-skills.ts
@@ -13,12 +13,17 @@ async function commandText(strings: TemplateStringsArray, ...values: string[]) {
 }
 
 function usage() {
-  return `Usage: bun run skills:sync <commit-sha>
+  return `Usage: bun run skills:sync [commit-sha-or-ref]
 
-  Pins vendored skills to an explicit upstream commit.
-  Downloads a tarball from ${SOURCE_REPO} at <commit-sha>,
+  Pins vendored skills to an upstream commit.
+  If omitted, syncs latest commit from the upstream default branch.
+  Downloads a tarball from ${SOURCE_REPO} at [commit-sha-or-ref],
   replaces the managed skill directories, and records provenance
   in ${SKILLS_DIR}/.upstream.json.`;
+}
+
+async function resolveDefaultBranch() {
+  return commandText`gh api repos/${SOURCE_REPO} --jq .default_branch`;
 }
 
 async function resolveCommit(inputSha: string) {
@@ -47,17 +52,19 @@ async function main() {
     console.log(usage());
     return;
   }
-  if (!arg) {
-    console.error("Error: commit SHA required. Run with --help for usage.");
-    process.exit(1);
-  }
 
-  const commit = await resolveCommit(arg);
+  const sourceRef = arg ?? (await resolveDefaultBranch());
+  const sourceRefType = arg ? "explicit" : "default_branch";
+  const commit = await resolveCommit(sourceRef);
   const tmp = await commandText`mktemp -d`;
   const tarball = `${tmp}/repo.tar.gz`;
 
   try {
-    await $`gh api repos/${SOURCE_REPO}/tarball/${commit} > ${tarball}`;
+    const tarballBytes = await $`gh api repos/${SOURCE_REPO}/tarball/${commit}`.bytes();
+    if (tarballBytes.byteLength === 0) {
+      throw new Error(`Downloaded empty tarball for ${SOURCE_REPO} ${commit}`);
+    }
+    await Bun.write(tarball, tarballBytes);
     await $`mkdir -p ${tmp}/extracted`;
     await $`tar -xzf ${tarball} -C ${tmp}/extracted`;
 
@@ -77,7 +84,8 @@ async function main() {
       source_release: null,
       source_version: null,
       source_commit: commit,
-      source_ref: arg,
+      source_ref: sourceRef,
+      source_ref_type: sourceRefType,
       synced_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
       managed_paths: MANAGED_SKILLS.map((skill) => `${SKILLS_DIR}/${skill}`),
     };

--- a/scripts/sync-agent-skills.ts
+++ b/scripts/sync-agent-skills.ts
@@ -1,7 +1,8 @@
-import { $ } from "bun";
 import { existsSync } from "node:fs";
-import { readdir, mkdir, copyFile } from "node:fs/promises";
-import { join, resolve } from "node:path";
+import { copyFile, mkdir, readdir } from "node:fs/promises";
+import { join } from "node:path";
+
+import { $ } from "bun";
 
 const SOURCE_REPO = "supabase/agent-skills";
 const SKILLS_DIR = "skills";
@@ -31,6 +32,14 @@ async function resolveCommit(inputSha: string) {
   return fullSha;
 }
 
+async function ensureGithubAuth() {
+  try {
+    await $`gh auth status --hostname github.com`;
+  } catch {
+    throw new Error("GitHub CLI authentication required. Run: gh auth login");
+  }
+}
+
 async function copyDir(srcDir: string, destDir: string) {
   await $`rm -rf ${destDir}`;
   await mkdir(destDir, { recursive: true });
@@ -52,6 +61,8 @@ async function main() {
     console.log(usage());
     return;
   }
+
+  await ensureGithubAuth();
 
   const sourceRef = arg ?? (await resolveDefaultBranch());
   const sourceRefType = arg ? "explicit" : "default_branch";

--- a/scripts/sync-agent-skills.ts
+++ b/scripts/sync-agent-skills.ts
@@ -1,23 +1,44 @@
 import { $ } from "bun";
+import { existsSync } from "node:fs";
+import { readdir, mkdir, copyFile } from "node:fs/promises";
+import { join, resolve } from "node:path";
 
 const SOURCE_REPO = "supabase/agent-skills";
 const SKILLS_DIR = "skills";
 const MANAGED_SKILLS = ["supabase", "supabase-postgres-best-practices"] as const;
-const ASSETS = MANAGED_SKILLS.map((skill) => `${skill}.tar.gz`);
+const UPSTREAM_SKILLS_DIR = "skills";
 
 async function commandText(strings: TemplateStringsArray, ...values: string[]) {
   return (await $(strings, ...values).text()).trim();
 }
 
 function usage() {
-  return `Usage: bun run skills:sync [release-tag]\n\nIf release-tag is omitted, the latest ${SOURCE_REPO} release is used.`;
+  return `Usage: bun run skills:sync <commit-sha>
+
+  Pins vendored skills to an explicit upstream commit.
+  Downloads a tarball from ${SOURCE_REPO} at <commit-sha>,
+  replaces the managed skill directories, and records provenance
+  in ${SKILLS_DIR}/.upstream.json.`;
 }
 
-async function resolveRelease(inputTag: string | undefined) {
-  const tag = inputTag ?? (await commandText`gh release view --repo ${SOURCE_REPO} --json tagName --jq .tagName`);
-  const version = tag.startsWith("v") ? tag.slice(1) : tag;
-  const commit = await commandText`gh release view ${tag} --repo ${SOURCE_REPO} --json targetCommitish --jq .targetCommitish`;
-  return { tag, version, commit };
+async function resolveCommit(inputSha: string) {
+  const fullSha = await commandText`gh api repos/${SOURCE_REPO}/commits/${inputSha} --jq .sha`;
+  return fullSha;
+}
+
+async function copyDir(srcDir: string, destDir: string) {
+  await $`rm -rf ${destDir}`;
+  await mkdir(destDir, { recursive: true });
+  const entries = await readdir(srcDir, { withFileTypes: true });
+  for (const entry of entries) {
+    const srcPath = join(srcDir, entry.name);
+    const destPath = join(destDir, entry.name);
+    if (entry.isDirectory()) {
+      await copyDir(srcPath, destPath);
+    } else {
+      await copyFile(srcPath, destPath);
+    }
+  }
 }
 
 async function main() {
@@ -26,31 +47,43 @@ async function main() {
     console.log(usage());
     return;
   }
+  if (!arg) {
+    console.error("Error: commit SHA required. Run with --help for usage.");
+    process.exit(1);
+  }
 
-  const release = await resolveRelease(arg);
+  const commit = await resolveCommit(arg);
   const tmp = await commandText`mktemp -d`;
+  const tarball = `${tmp}/repo.tar.gz`;
 
   try {
-    await $`mkdir -p ${SKILLS_DIR}`;
-    await $`gh release download ${release.tag} --repo ${SOURCE_REPO} --dir ${tmp} --pattern ${ASSETS[0]} --pattern ${ASSETS[1]}`;
+    await $`gh api repos/${SOURCE_REPO}/tarball/${commit} > ${tarball}`;
+    await $`mkdir -p ${tmp}/extracted`;
+    await $`tar -xzf ${tarball} -C ${tmp}/extracted`;
+
+    const extractedDirs = await readdir(`${tmp}/extracted`);
+    const repoRoot = `${tmp}/extracted/${extractedDirs[0]}`;
 
     for (const skill of MANAGED_SKILLS) {
-      await $`rm -rf ${SKILLS_DIR}/${skill}`;
-      await $`tar -xzf ${tmp}/${skill}.tar.gz -C ${SKILLS_DIR}`;
+      const srcPath = join(repoRoot, UPSTREAM_SKILLS_DIR, skill);
+      if (!existsSync(srcPath)) {
+        throw new Error(`Skill directory not found in upstream: ${UPSTREAM_SKILLS_DIR}/${skill}`);
+      }
+      await copyDir(srcPath, `${SKILLS_DIR}/${skill}`);
     }
 
     const metadata = {
       source_repo: SOURCE_REPO,
-      source_release: release.tag,
-      source_version: release.version,
-      source_commit: release.commit,
+      source_release: null,
+      source_version: null,
+      source_commit: commit,
+      source_ref: arg,
       synced_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
       managed_paths: MANAGED_SKILLS.map((skill) => `${SKILLS_DIR}/${skill}`),
-      assets: ASSETS,
     };
 
     await Bun.write(`${SKILLS_DIR}/.upstream.json`, `${JSON.stringify(metadata, null, 2)}\n`);
-    console.log(`Synced ${SOURCE_REPO} ${release.tag} into ${SKILLS_DIR}/`);
+    console.log(`Synced ${SOURCE_REPO} ${commit.slice(0, 7)} into ${SKILLS_DIR}/`);
   } finally {
     await $`rm -rf ${tmp}`;
   }

--- a/scripts/sync-agent-skills.ts
+++ b/scripts/sync-agent-skills.ts
@@ -1,0 +1,62 @@
+import { $ } from "bun";
+
+const SOURCE_REPO = "supabase/agent-skills";
+const SKILLS_DIR = "skills";
+const MANAGED_SKILLS = ["supabase", "supabase-postgres-best-practices"] as const;
+const ASSETS = MANAGED_SKILLS.map((skill) => `${skill}.tar.gz`);
+
+async function commandText(strings: TemplateStringsArray, ...values: string[]) {
+  return (await $(strings, ...values).text()).trim();
+}
+
+function usage() {
+  return `Usage: bun run skills:sync [release-tag]\n\nIf release-tag is omitted, the latest ${SOURCE_REPO} release is used.`;
+}
+
+async function resolveRelease(inputTag: string | undefined) {
+  const tag = inputTag ?? (await commandText`gh release view --repo ${SOURCE_REPO} --json tagName --jq .tagName`);
+  const version = tag.startsWith("v") ? tag.slice(1) : tag;
+  const commit = await commandText`gh release view ${tag} --repo ${SOURCE_REPO} --json targetCommitish --jq .targetCommitish`;
+  return { tag, version, commit };
+}
+
+async function main() {
+  const arg = Bun.argv[2];
+  if (arg === "--help" || arg === "-h") {
+    console.log(usage());
+    return;
+  }
+
+  const release = await resolveRelease(arg);
+  const tmp = await commandText`mktemp -d`;
+
+  try {
+    await $`mkdir -p ${SKILLS_DIR}`;
+    await $`gh release download ${release.tag} --repo ${SOURCE_REPO} --dir ${tmp} --pattern ${ASSETS[0]} --pattern ${ASSETS[1]}`;
+
+    for (const skill of MANAGED_SKILLS) {
+      await $`rm -rf ${SKILLS_DIR}/${skill}`;
+      await $`tar -xzf ${tmp}/${skill}.tar.gz -C ${SKILLS_DIR}`;
+    }
+
+    const metadata = {
+      source_repo: SOURCE_REPO,
+      source_release: release.tag,
+      source_version: release.version,
+      source_commit: release.commit,
+      synced_at: new Date().toISOString().replace(/\.\d{3}Z$/, "Z"),
+      managed_paths: MANAGED_SKILLS.map((skill) => `${SKILLS_DIR}/${skill}`),
+      assets: ASSETS,
+    };
+
+    await Bun.write(`${SKILLS_DIR}/.upstream.json`, `${JSON.stringify(metadata, null, 2)}\n`);
+    console.log(`Synced ${SOURCE_REPO} ${release.tag} into ${SKILLS_DIR}/`);
+  } finally {
+    await $`rm -rf ${tmp}`;
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exit(1);
+});

--- a/skills/.upstream.json
+++ b/skills/.upstream.json
@@ -1,0 +1,15 @@
+{
+  "source_repo": "supabase/agent-skills",
+  "source_release": null,
+  "source_version": null,
+  "source_commit": null,
+  "synced_at": null,
+  "managed_paths": [
+    "skills/supabase",
+    "skills/supabase-postgres-best-practices"
+  ],
+  "assets": [
+    "supabase.tar.gz",
+    "supabase-postgres-best-practices.tar.gz"
+  ]
+}

--- a/skills/.upstream.json
+++ b/skills/.upstream.json
@@ -3,8 +3,9 @@
   "source_release": null,
   "source_version": null,
   "source_commit": "4bb13d858d19f1f848505a66f46fc9603fdcde95",
-  "source_ref": "4bb13d858d19f1f848505a66f46fc9603fdcde95",
-  "synced_at": "2026-05-04T15:13:44Z",
+  "source_ref": "main",
+  "source_ref_type": "default_branch",
+  "synced_at": "2026-05-05T06:52:22Z",
   "managed_paths": [
     "skills/supabase",
     "skills/supabase-postgres-best-practices"

--- a/skills/.upstream.json
+++ b/skills/.upstream.json
@@ -2,14 +2,11 @@
   "source_repo": "supabase/agent-skills",
   "source_release": null,
   "source_version": null,
-  "source_commit": null,
-  "synced_at": null,
+  "source_commit": "4bb13d858d19f1f848505a66f46fc9603fdcde95",
+  "source_ref": "4bb13d858d19f1f848505a66f46fc9603fdcde95",
+  "synced_at": "2026-05-04T15:13:44Z",
   "managed_paths": [
     "skills/supabase",
     "skills/supabase-postgres-best-practices"
-  ],
-  "assets": [
-    "supabase.tar.gz",
-    "supabase-postgres-best-practices.tar.gz"
   ]
 }

--- a/skills/supabase-postgres-best-practices/SKILL.md
+++ b/skills/supabase-postgres-best-practices/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: supabase-postgres-best-practices
+description: Postgres performance optimization and best practices from Supabase. Use this skill when writing, reviewing, or optimizing Postgres queries, schema designs, or database configurations.
+license: MIT
+metadata:
+  author: supabase
+  version: "1.1.1"
+  organization: Supabase
+  date: January 2026
+  abstract: Comprehensive Postgres performance optimization guide for developers using Supabase and Postgres. Contains performance rules across 8 categories, prioritized by impact from critical (query performance, connection management) to incremental (advanced features). Each rule includes detailed explanations, incorrect vs. correct SQL examples, query plan analysis, and specific performance metrics to guide automated optimization and code generation.
+---
+
+# Supabase Postgres Best Practices
+
+Comprehensive performance optimization guide for Postgres, maintained by Supabase. Contains rules across 8 categories, prioritized by impact to guide automated query optimization and schema design.
+
+## When to Apply
+
+Reference these guidelines when:
+- Writing SQL queries or designing schemas
+- Implementing indexes or query optimization
+- Reviewing database performance issues
+- Configuring connection pooling or scaling
+- Optimizing for Postgres-specific features
+- Working with Row-Level Security (RLS)
+
+## Rule Categories by Priority
+
+| Priority | Category | Impact | Prefix |
+|----------|----------|--------|--------|
+| 1 | Query Performance | CRITICAL | `query-` |
+| 2 | Connection Management | CRITICAL | `conn-` |
+| 3 | Security & RLS | CRITICAL | `security-` |
+| 4 | Schema Design | HIGH | `schema-` |
+| 5 | Concurrency & Locking | MEDIUM-HIGH | `lock-` |
+| 6 | Data Access Patterns | MEDIUM | `data-` |
+| 7 | Monitoring & Diagnostics | LOW-MEDIUM | `monitor-` |
+| 8 | Advanced Features | LOW | `advanced-` |
+
+## How to Use
+
+Read individual rule files for detailed explanations and SQL examples:
+
+```
+references/query-missing-indexes.md
+references/query-partial-indexes.md
+references/_sections.md
+```
+
+Each rule file contains:
+- Brief explanation of why it matters
+- Incorrect SQL example with explanation
+- Correct SQL example with explanation
+- Optional EXPLAIN output or metrics
+- Additional context and references
+- Supabase-specific notes (when applicable)
+
+## References
+
+- https://www.postgresql.org/docs/current/
+- https://supabase.com/docs
+- https://wiki.postgresql.org/wiki/Performance_Optimization
+- https://supabase.com/docs/guides/database/overview
+- https://supabase.com/docs/guides/auth/row-level-security

--- a/skills/supabase-postgres-best-practices/references/_contributing.md
+++ b/skills/supabase-postgres-best-practices/references/_contributing.md
@@ -1,0 +1,170 @@
+# Writing Guidelines for Postgres References
+
+This document provides guidelines for creating effective Postgres best
+practice references that work well with AI agents and LLMs.
+
+## Key Principles
+
+### 1. Concrete Transformation Patterns
+
+Show exact SQL rewrites. Avoid philosophical advice.
+
+**Good:** "Use `WHERE id = ANY(ARRAY[...])` instead of
+`WHERE id IN (SELECT ...)`" **Bad:** "Design good schemas"
+
+### 2. Error-First Structure
+
+Always show the problematic pattern first, then the solution. This trains agents
+to recognize anti-patterns.
+
+```markdown
+**Incorrect (sequential queries):** [bad example]
+
+**Correct (batched query):** [good example]
+```
+
+### 3. Quantified Impact
+
+Include specific metrics. Helps agents prioritize fixes.
+
+**Good:** "10x faster queries", "50% smaller index", "Eliminates N+1" 
+**Bad:** "Faster", "Better", "More efficient"
+
+### 4. Self-Contained Examples
+
+Examples should be complete and runnable (or close to it). Include `CREATE TABLE`
+if context is needed.
+
+```sql
+-- Include table definition when needed for clarity
+CREATE TABLE users (
+  id bigint PRIMARY KEY,
+  email text NOT NULL,
+  deleted_at timestamptz
+);
+
+-- Now show the index
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+```
+
+### 5. Semantic Naming
+
+Use meaningful table/column names. Names carry intent for LLMs.
+
+**Good:** `users`, `email`, `created_at`, `is_active`
+**Bad:** `table1`, `col1`, `field`, `flag`
+
+---
+
+## Code Example Standards
+
+### SQL Formatting
+
+```sql
+-- Use lowercase keywords, clear formatting
+CREATE INDEX CONCURRENTLY users_email_idx
+  ON users(email)
+  WHERE deleted_at IS NULL;
+
+-- Not cramped or ALL CAPS
+CREATE INDEX CONCURRENTLY USERS_EMAIL_IDX ON USERS(EMAIL) WHERE DELETED_AT IS NULL;
+```
+
+### Comments
+
+- Explain _why_, not _what_
+- Highlight performance implications
+- Point out common pitfalls
+
+### Language Tags
+
+- `sql` - Standard SQL queries
+- `plpgsql` - Stored procedures/functions
+- `typescript` - Application code (when needed)
+- `python` - Application code (when needed)
+
+---
+
+## When to Include Application Code
+
+**Default: SQL Only**
+
+Most references should focus on pure SQL patterns. This keeps examples portable.
+
+**Include Application Code When:**
+
+- Connection pooling configuration
+- Transaction management in application context
+- ORM anti-patterns (N+1 in Prisma/TypeORM)
+- Prepared statement usage
+
+**Format for Mixed Examples:**
+
+````markdown
+**Incorrect (N+1 in application):**
+
+```typescript
+for (const user of users) {
+  const posts = await db.query("SELECT * FROM posts WHERE user_id = $1", [
+    user.id,
+  ]);
+}
+```
+````
+
+**Correct (batch query):**
+
+```typescript
+const posts = await db.query("SELECT * FROM posts WHERE user_id = ANY($1)", [
+  userIds,
+]);
+```
+
+---
+
+## Impact Level Guidelines
+
+| Level | Improvement | Use When |
+|-------|-------------|----------|
+| **CRITICAL** | 10-100x | Missing indexes, connection exhaustion, sequential scans on large tables |
+| **HIGH** | 5-20x | Wrong index types, poor partitioning, missing covering indexes |
+| **MEDIUM-HIGH** | 2-5x | N+1 queries, inefficient pagination, RLS optimization |
+| **MEDIUM** | 1.5-3x | Redundant indexes, query plan instability |
+| **LOW-MEDIUM** | 1.2-2x | VACUUM tuning, configuration tweaks |
+| **LOW** | Incremental | Advanced patterns, edge cases |
+
+---
+
+## Reference Standards
+
+**Primary Sources:**
+
+- Official Postgres documentation
+- Supabase documentation
+- Postgres wiki
+- Established blogs (2ndQuadrant, Crunchy Data)
+
+**Format:**
+
+```markdown
+Reference:
+[Postgres Indexes](https://www.postgresql.org/docs/current/indexes.html)
+```
+
+---
+
+## Review Checklist
+
+Before submitting a reference:
+
+- [ ] Title is clear and action-oriented
+- [ ] Impact level matches the performance gain
+- [ ] impactDescription includes quantification
+- [ ] Explanation is concise (1-2 sentences)
+- [ ] Has at least 1 **Incorrect** SQL example
+- [ ] Has at least 1 **Correct** SQL example
+- [ ] SQL uses semantic naming
+- [ ] Comments explain _why_, not _what_
+- [ ] Trade-offs mentioned if applicable
+- [ ] Reference links included
+- [ ] `pnpm test` passes

--- a/skills/supabase-postgres-best-practices/references/_contributing.md
+++ b/skills/supabase-postgres-best-practices/references/_contributing.md
@@ -27,7 +27,7 @@ to recognize anti-patterns.
 
 Include specific metrics. Helps agents prioritize fixes.
 
-**Good:** "10x faster queries", "50% smaller index", "Eliminates N+1" 
+**Good:** "10x faster queries", "50% smaller index", "Eliminates N+1"
 **Bad:** "Faster", "Better", "More efficient"
 
 ### 4. Self-Contained Examples

--- a/skills/supabase-postgres-best-practices/references/_sections.md
+++ b/skills/supabase-postgres-best-practices/references/_sections.md
@@ -1,0 +1,39 @@
+# Section Definitions
+
+This file defines the rule categories for Postgres best practices. Rules are automatically assigned to sections based on their filename prefix.
+
+Take the examples below as pure demonstrative. Replace each section with the actual rule categories for Postgres best practices.
+
+---
+
+## 1. Query Performance (query)
+**Impact:** CRITICAL
+**Description:** Slow queries, missing indexes, inefficient query plans. The most common source of Postgres performance issues.
+
+## 2. Connection Management (conn)
+**Impact:** CRITICAL
+**Description:** Connection pooling, limits, and serverless strategies. Critical for applications with high concurrency or serverless deployments.
+
+## 3. Security & RLS (security)
+**Impact:** CRITICAL
+**Description:** Row-Level Security policies, privilege management, and authentication patterns.
+
+## 4. Schema Design (schema)
+**Impact:** HIGH
+**Description:** Table design, index strategies, partitioning, and data type selection. Foundation for long-term performance.
+
+## 5. Concurrency & Locking (lock)
+**Impact:** MEDIUM-HIGH
+**Description:** Transaction management, isolation levels, deadlock prevention, and lock contention patterns.
+
+## 6. Data Access Patterns (data)
+**Impact:** MEDIUM
+**Description:** N+1 query elimination, batch operations, cursor-based pagination, and efficient data fetching.
+
+## 7. Monitoring & Diagnostics (monitor)
+**Impact:** LOW-MEDIUM
+**Description:** Using pg_stat_statements, EXPLAIN ANALYZE, metrics collection, and performance diagnostics.
+
+## 8. Advanced Features (advanced)
+**Impact:** LOW
+**Description:** Full-text search, JSONB optimization, PostGIS, extensions, and advanced Postgres features.

--- a/skills/supabase-postgres-best-practices/references/_template.md
+++ b/skills/supabase-postgres-best-practices/references/_template.md
@@ -1,0 +1,34 @@
+---
+title: Clear, Action-Oriented Title (e.g., "Use Partial Indexes for Filtered Queries")
+impact: MEDIUM
+impactDescription: 5-20x query speedup for filtered queries
+tags: indexes, query-optimization, performance
+---
+
+## [Rule Title]
+
+[1-2 sentence explanation of the problem and why it matters. Focus on performance impact.]
+
+**Incorrect (describe the problem):**
+
+```sql
+-- Comment explaining what makes this slow/problematic
+CREATE INDEX users_email_idx ON users(email);
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- This scans deleted records unnecessarily
+```
+
+**Correct (describe the solution):**
+
+```sql
+-- Comment explaining why this is better
+CREATE INDEX users_active_email_idx ON users(email) WHERE deleted_at IS NULL;
+
+SELECT * FROM users WHERE email = 'user@example.com' AND deleted_at IS NULL;
+-- Only indexes active users, 10x smaller index, faster queries
+```
+
+[Optional: Additional context, edge cases, or trade-offs]
+
+Reference: [Postgres Docs](https://www.postgresql.org/docs/current/)

--- a/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
+++ b/skills/supabase-postgres-best-practices/references/advanced-full-text-search.md
@@ -1,0 +1,55 @@
+---
+title: Use tsvector for Full-Text Search
+impact: MEDIUM
+impactDescription: 100x faster than LIKE, with ranking support
+tags: full-text-search, tsvector, gin, search
+---
+
+## Use tsvector for Full-Text Search
+
+LIKE with wildcards can't use indexes. Full-text search with tsvector is orders of magnitude faster.
+
+**Incorrect (LIKE pattern matching):**
+
+```sql
+-- Cannot use index, scans all rows
+select * from articles where content like '%postgresql%';
+
+-- Case-insensitive makes it worse
+select * from articles where lower(content) like '%postgresql%';
+```
+
+**Correct (full-text search with tsvector):**
+
+```sql
+-- Add tsvector column and index
+alter table articles add column search_vector tsvector
+  generated always as (to_tsvector('english', coalesce(title,'') || ' ' || coalesce(content,''))) stored;
+
+create index articles_search_idx on articles using gin (search_vector);
+
+-- Fast full-text search
+select * from articles
+where search_vector @@ to_tsquery('english', 'postgresql & performance');
+
+-- With ranking
+select *, ts_rank(search_vector, query) as rank
+from articles, to_tsquery('english', 'postgresql') query
+where search_vector @@ query
+order by rank desc;
+```
+
+Search multiple terms:
+
+```sql
+-- AND: both terms required
+to_tsquery('postgresql & performance')
+
+-- OR: either term
+to_tsquery('postgresql | mysql')
+
+-- Prefix matching
+to_tsquery('post:*')
+```
+
+Reference: [Full Text Search](https://supabase.com/docs/guides/database/full-text-search)

--- a/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
+++ b/skills/supabase-postgres-best-practices/references/advanced-jsonb-indexing.md
@@ -1,0 +1,49 @@
+---
+title: Index JSONB Columns for Efficient Querying
+impact: MEDIUM
+impactDescription: 10-100x faster JSONB queries with proper indexing
+tags: jsonb, gin, indexes, json
+---
+
+## Index JSONB Columns for Efficient Querying
+
+JSONB queries without indexes scan the entire table. Use GIN indexes for containment queries.
+
+**Incorrect (no index on JSONB):**
+
+```sql
+create table products (
+  id bigint primary key,
+  attributes jsonb
+);
+
+-- Full table scan for every query
+select * from products where attributes @> '{"color": "red"}';
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+**Correct (GIN index for JSONB):**
+
+```sql
+-- GIN index for containment operators (@>, ?, ?&, ?|)
+create index products_attrs_gin on products using gin (attributes);
+
+-- Now containment queries use the index
+select * from products where attributes @> '{"color": "red"}';
+
+-- For specific key lookups, use expression index
+create index products_brand_idx on products ((attributes->>'brand'));
+select * from products where attributes->>'brand' = 'Nike';
+```
+
+Choose the right operator class:
+
+```sql
+-- jsonb_ops (default): supports all operators, larger index
+create index idx1 on products using gin (attributes);
+
+-- jsonb_path_ops: only @> operator, but 2-3x smaller index
+create index idx2 on products using gin (attributes jsonb_path_ops);
+```
+
+Reference: [JSONB Indexes](https://www.postgresql.org/docs/current/datatype-json.html#JSON-INDEXING)

--- a/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
+++ b/skills/supabase-postgres-best-practices/references/conn-idle-timeout.md
@@ -1,0 +1,46 @@
+---
+title: Configure Idle Connection Timeouts
+impact: HIGH
+impactDescription: Reclaim 30-50% of connection slots from idle clients
+tags: connections, timeout, idle, resource-management
+---
+
+## Configure Idle Connection Timeouts
+
+Idle connections waste resources. Configure timeouts to automatically reclaim them.
+
+**Incorrect (connections held indefinitely):**
+
+```sql
+-- No timeout configured
+show idle_in_transaction_session_timeout;  -- 0 (disabled)
+
+-- Connections stay open forever, even when idle
+select pid, state, state_change, query
+from pg_stat_activity
+where state = 'idle in transaction';
+-- Shows transactions idle for hours, holding locks
+```
+
+**Correct (automatic cleanup of idle connections):**
+
+```sql
+-- Terminate connections idle in transaction after 30 seconds
+alter system set idle_in_transaction_session_timeout = '30s';
+
+-- Terminate completely idle connections after 10 minutes
+alter system set idle_session_timeout = '10min';
+
+-- Reload configuration
+select pg_reload_conf();
+```
+
+For pooled connections, configure at the pooler level:
+
+```ini
+# pgbouncer.ini
+server_idle_timeout = 60
+client_idle_timeout = 300
+```
+
+Reference: [Connection Timeouts](https://www.postgresql.org/docs/current/runtime-config-client.html#GUC-IDLE-IN-TRANSACTION-SESSION-TIMEOUT)

--- a/skills/supabase-postgres-best-practices/references/conn-limits.md
+++ b/skills/supabase-postgres-best-practices/references/conn-limits.md
@@ -1,0 +1,44 @@
+---
+title: Set Appropriate Connection Limits
+impact: CRITICAL
+impactDescription: Prevent database crashes and memory exhaustion
+tags: connections, max-connections, limits, stability
+---
+
+## Set Appropriate Connection Limits
+
+Too many connections exhaust memory and degrade performance. Set limits based on available resources.
+
+**Incorrect (unlimited or excessive connections):**
+
+```sql
+-- Default max_connections = 100, but often increased blindly
+show max_connections;  -- 500 (way too high for 4GB RAM)
+
+-- Each connection uses 1-3MB RAM
+-- 500 connections * 2MB = 1GB just for connections!
+-- Out of memory errors under load
+```
+
+**Correct (calculate based on resources):**
+
+```sql
+-- Formula: max_connections = (RAM in MB / 5MB per connection) - reserved
+-- For 4GB RAM: (4096 / 5) - 10 = ~800 theoretical max
+-- But practically, 100-200 is better for query performance
+
+-- Recommended settings for 4GB RAM
+alter system set max_connections = 100;
+
+-- Also set work_mem appropriately
+-- work_mem * max_connections should not exceed 25% of RAM
+alter system set work_mem = '8MB';  -- 8MB * 100 = 800MB max
+```
+
+Monitor connection usage:
+
+```sql
+select count(*), state from pg_stat_activity group by state;
+```
+
+Reference: [Database Connections](https://supabase.com/docs/guides/platform/performance#connection-management)

--- a/skills/supabase-postgres-best-practices/references/conn-pooling.md
+++ b/skills/supabase-postgres-best-practices/references/conn-pooling.md
@@ -1,0 +1,41 @@
+---
+title: Use Connection Pooling for All Applications
+impact: CRITICAL
+impactDescription: Handle 10-100x more concurrent users
+tags: connection-pooling, pgbouncer, performance, scalability
+---
+
+## Use Connection Pooling for All Applications
+
+Postgres connections are expensive (1-3MB RAM each). Without pooling, applications exhaust connections under load.
+
+**Incorrect (new connection per request):**
+
+```sql
+-- Each request creates a new connection
+-- Application code: db.connect() per request
+-- Result: 500 concurrent users = 500 connections = crashed database
+
+-- Check current connections
+select count(*) from pg_stat_activity;  -- 487 connections!
+```
+
+**Correct (connection pooling):**
+
+```sql
+-- Use a pooler like PgBouncer between app and database
+-- Application connects to pooler, pooler reuses a small pool to Postgres
+
+-- Configure pool_size based on: (CPU cores * 2) + spindle_count
+-- Example for 4 cores: pool_size = 10
+
+-- Result: 500 concurrent users share 10 actual connections
+select count(*) from pg_stat_activity;  -- 10 connections
+```
+
+Pool modes:
+
+- **Transaction mode**: connection returned after each transaction (best for most apps)
+- **Session mode**: connection held for entire session (needed for prepared statements, temp tables)
+
+Reference: [Connection Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pooler)

--- a/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
+++ b/skills/supabase-postgres-best-practices/references/conn-prepared-statements.md
@@ -1,0 +1,46 @@
+---
+title: Use Prepared Statements Correctly with Pooling
+impact: HIGH
+impactDescription: Avoid prepared statement conflicts in pooled environments
+tags: prepared-statements, connection-pooling, transaction-mode
+---
+
+## Use Prepared Statements Correctly with Pooling
+
+Prepared statements are tied to individual database connections. In transaction-mode pooling, connections are shared, causing conflicts.
+
+**Incorrect (named prepared statements with transaction pooling):**
+
+```sql
+-- Named prepared statement
+prepare get_user as select * from users where id = $1;
+
+-- In transaction mode pooling, next request may get different connection
+execute get_user(123);
+-- ERROR: prepared statement "get_user" does not exist
+```
+
+**Correct (use unnamed statements or session mode):**
+
+```sql
+-- Option 1: Use unnamed prepared statements (most ORMs do this automatically)
+-- The query is prepared and executed in a single protocol message
+
+-- Option 2: Deallocate after use in transaction mode
+prepare get_user as select * from users where id = $1;
+execute get_user(123);
+deallocate get_user;
+
+-- Option 3: Use session mode pooling (port 5432 vs 6543)
+-- Connection is held for entire session, prepared statements persist
+```
+
+Check your driver settings:
+
+```sql
+-- Many drivers use prepared statements by default
+-- Node.js pg: { prepare: false } to disable
+-- JDBC: prepareThreshold=0 to disable
+```
+
+Reference: [Prepared Statements with Pooling](https://supabase.com/docs/guides/database/connecting-to-postgres#connection-pool-modes)

--- a/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
+++ b/skills/supabase-postgres-best-practices/references/data-batch-inserts.md
@@ -1,0 +1,54 @@
+---
+title: Batch INSERT Statements for Bulk Data
+impact: MEDIUM
+impactDescription: 10-50x faster bulk inserts
+tags: batch, insert, bulk, performance, copy
+---
+
+## Batch INSERT Statements for Bulk Data
+
+Individual INSERT statements have high overhead. Batch multiple rows in single statements or use COPY.
+
+**Incorrect (individual inserts):**
+
+```sql
+-- Each insert is a separate transaction and round trip
+insert into events (user_id, action) values (1, 'click');
+insert into events (user_id, action) values (1, 'view');
+insert into events (user_id, action) values (2, 'click');
+-- ... 1000 more individual inserts
+
+-- 1000 inserts = 1000 round trips = slow
+```
+
+**Correct (batch insert):**
+
+```sql
+-- Multiple rows in single statement
+insert into events (user_id, action) values
+  (1, 'click'),
+  (1, 'view'),
+  (2, 'click'),
+  -- ... up to ~1000 rows per batch
+  (999, 'view');
+
+-- One round trip for 1000 rows
+```
+
+For large imports, use COPY:
+
+```sql
+-- COPY is fastest for bulk loading
+copy events (user_id, action, created_at)
+from '/path/to/data.csv'
+with (format csv, header true);
+
+-- Or from stdin in application
+copy events (user_id, action) from stdin with (format csv);
+1,click
+1,view
+2,click
+\.
+```
+
+Reference: [COPY](https://www.postgresql.org/docs/current/sql-copy.html)

--- a/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
+++ b/skills/supabase-postgres-best-practices/references/data-n-plus-one.md
@@ -1,0 +1,53 @@
+---
+title: Eliminate N+1 Queries with Batch Loading
+impact: MEDIUM-HIGH
+impactDescription: 10-100x fewer database round trips
+tags: n-plus-one, batch, performance, queries
+---
+
+## Eliminate N+1 Queries with Batch Loading
+
+N+1 queries execute one query per item in a loop. Batch them into a single query using arrays or JOINs.
+
+**Incorrect (N+1 queries):**
+
+```sql
+-- First query: get all users
+select id from users where active = true;  -- Returns 100 IDs
+
+-- Then N queries, one per user
+select * from orders where user_id = 1;
+select * from orders where user_id = 2;
+select * from orders where user_id = 3;
+-- ... 97 more queries!
+
+-- Total: 101 round trips to database
+```
+
+**Correct (single batch query):**
+
+```sql
+-- Collect IDs and query once with ANY
+select * from orders where user_id = any(array[1, 2, 3, ...]);
+
+-- Or use JOIN instead of loop
+select u.id, u.name, o.*
+from users u
+left join orders o on o.user_id = u.id
+where u.active = true;
+
+-- Total: 1 round trip
+```
+
+Application pattern:
+
+```sql
+-- Instead of looping in application code:
+-- for user in users: db.query("SELECT * FROM orders WHERE user_id = $1", user.id)
+
+-- Pass array parameter:
+select * from orders where user_id = any($1::bigint[]);
+-- Application passes: [1, 2, 3, 4, 5, ...]
+```
+
+Reference: [N+1 Query Problem](https://supabase.com/docs/guides/database/query-optimization)

--- a/skills/supabase-postgres-best-practices/references/data-pagination.md
+++ b/skills/supabase-postgres-best-practices/references/data-pagination.md
@@ -1,0 +1,50 @@
+---
+title: Use Cursor-Based Pagination Instead of OFFSET
+impact: MEDIUM-HIGH
+impactDescription: Consistent O(1) performance regardless of page depth
+tags: pagination, cursor, keyset, offset, performance
+---
+
+## Use Cursor-Based Pagination Instead of OFFSET
+
+OFFSET-based pagination scans all skipped rows, getting slower on deeper pages. Cursor pagination is O(1).
+
+**Incorrect (OFFSET pagination):**
+
+```sql
+-- Page 1: scans 20 rows
+select * from products order by id limit 20 offset 0;
+
+-- Page 100: scans 2000 rows to skip 1980
+select * from products order by id limit 20 offset 1980;
+
+-- Page 10000: scans 200,000 rows!
+select * from products order by id limit 20 offset 199980;
+```
+
+**Correct (cursor/keyset pagination):**
+
+```sql
+-- Page 1: get first 20
+select * from products order by id limit 20;
+-- Application stores last_id = 20
+
+-- Page 2: start after last ID
+select * from products where id > 20 order by id limit 20;
+-- Uses index, always fast regardless of page depth
+
+-- Page 10000: same speed as page 1
+select * from products where id > 199980 order by id limit 20;
+```
+
+For multi-column sorting:
+
+```sql
+-- Cursor must include all sort columns
+select * from products
+where (created_at, id) > ('2024-01-15 10:00:00', 12345)
+order by created_at, id
+limit 20;
+```
+
+Reference: [Pagination](https://supabase.com/docs/guides/database/pagination)

--- a/skills/supabase-postgres-best-practices/references/data-upsert.md
+++ b/skills/supabase-postgres-best-practices/references/data-upsert.md
@@ -1,0 +1,50 @@
+---
+title: Use UPSERT for Insert-or-Update Operations
+impact: MEDIUM
+impactDescription: Atomic operation, eliminates race conditions
+tags: upsert, on-conflict, insert, update
+---
+
+## Use UPSERT for Insert-or-Update Operations
+
+Using separate SELECT-then-INSERT/UPDATE creates race conditions. Use INSERT ... ON CONFLICT for atomic upserts.
+
+**Incorrect (check-then-insert race condition):**
+
+```sql
+-- Race condition: two requests check simultaneously
+select * from settings where user_id = 123 and key = 'theme';
+-- Both find nothing
+
+-- Both try to insert
+insert into settings (user_id, key, value) values (123, 'theme', 'dark');
+-- One succeeds, one fails with duplicate key error!
+```
+
+**Correct (atomic UPSERT):**
+
+```sql
+-- Single atomic operation
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value, updated_at = now();
+
+-- Returns the inserted/updated row
+insert into settings (user_id, key, value)
+values (123, 'theme', 'dark')
+on conflict (user_id, key)
+do update set value = excluded.value
+returning *;
+```
+
+Insert-or-ignore pattern:
+
+```sql
+-- Insert only if not exists (no update)
+insert into page_views (page_id, user_id)
+values (1, 123)
+on conflict (page_id, user_id) do nothing;
+```
+
+Reference: [INSERT ON CONFLICT](https://www.postgresql.org/docs/current/sql-insert.html#SQL-ON-CONFLICT)

--- a/skills/supabase-postgres-best-practices/references/lock-advisory.md
+++ b/skills/supabase-postgres-best-practices/references/lock-advisory.md
@@ -1,0 +1,56 @@
+---
+title: Use Advisory Locks for Application-Level Locking
+impact: MEDIUM
+impactDescription: Efficient coordination without row-level lock overhead
+tags: advisory-locks, coordination, application-locks
+---
+
+## Use Advisory Locks for Application-Level Locking
+
+Advisory locks provide application-level coordination without requiring database rows to lock.
+
+**Incorrect (creating rows just for locking):**
+
+```sql
+-- Creating dummy rows to lock on
+create table resource_locks (
+  resource_name text primary key
+);
+
+insert into resource_locks values ('report_generator');
+
+-- Lock by selecting the row
+select * from resource_locks where resource_name = 'report_generator' for update;
+```
+
+**Correct (advisory locks):**
+
+```sql
+-- Session-level advisory lock (released on disconnect or unlock)
+select pg_advisory_lock(hashtext('report_generator'));
+-- ... do exclusive work ...
+select pg_advisory_unlock(hashtext('report_generator'));
+
+-- Transaction-level lock (released on commit/rollback)
+begin;
+select pg_advisory_xact_lock(hashtext('daily_report'));
+-- ... do work ...
+commit;  -- Lock automatically released
+```
+
+Try-lock for non-blocking operations:
+
+```sql
+-- Returns immediately with true/false instead of waiting
+select pg_try_advisory_lock(hashtext('resource_name'));
+
+-- Use in application
+if (acquired) {
+  -- Do work
+  select pg_advisory_unlock(hashtext('resource_name'));
+} else {
+  -- Skip or retry later
+}
+```
+
+Reference: [Advisory Locks](https://www.postgresql.org/docs/current/explicit-locking.html#ADVISORY-LOCKS)

--- a/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
+++ b/skills/supabase-postgres-best-practices/references/lock-deadlock-prevention.md
@@ -1,0 +1,68 @@
+---
+title: Prevent Deadlocks with Consistent Lock Ordering
+impact: MEDIUM-HIGH
+impactDescription: Eliminate deadlock errors, improve reliability
+tags: deadlocks, locking, transactions, ordering
+---
+
+## Prevent Deadlocks with Consistent Lock Ordering
+
+Deadlocks occur when transactions lock resources in different orders. Always
+acquire locks in a consistent order.
+
+**Incorrect (inconsistent lock ordering):**
+
+```sql
+-- Transaction A                    -- Transaction B
+begin;                              begin;
+update accounts                     update accounts
+set balance = balance - 100         set balance = balance - 50
+where id = 1;                       where id = 2;  -- B locks row 2
+
+update accounts                     update accounts
+set balance = balance + 100         set balance = balance + 50
+where id = 2;  -- A waits for B     where id = 1;  -- B waits for A
+
+-- DEADLOCK! Both waiting for each other
+```
+
+**Correct (lock rows in consistent order first):**
+
+```sql
+-- Explicitly acquire locks in ID order before updating
+begin;
+select * from accounts where id in (1, 2) order by id for update;
+
+-- Now perform updates in any order - locks already held
+update accounts set balance = balance - 100 where id = 1;
+update accounts set balance = balance + 100 where id = 2;
+commit;
+```
+
+Alternative: use a single statement to update atomically:
+
+```sql
+-- Single statement acquires all locks atomically
+begin;
+update accounts
+set balance = balance + case id
+  when 1 then -100
+  when 2 then 100
+end
+where id in (1, 2);
+commit;
+```
+
+Detect deadlocks in logs:
+
+```sql
+-- Check for recent deadlocks
+select * from pg_stat_database where deadlocks > 0;
+
+-- Enable deadlock logging
+set log_lock_waits = on;
+set deadlock_timeout = '1s';
+```
+
+Reference:
+[Deadlocks](https://www.postgresql.org/docs/current/explicit-locking.html#LOCKING-DEADLOCKS)

--- a/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
+++ b/skills/supabase-postgres-best-practices/references/lock-short-transactions.md
@@ -1,0 +1,50 @@
+---
+title: Keep Transactions Short to Reduce Lock Contention
+impact: MEDIUM-HIGH
+impactDescription: 3-5x throughput improvement, fewer deadlocks
+tags: transactions, locking, contention, performance
+---
+
+## Keep Transactions Short to Reduce Lock Contention
+
+Long-running transactions hold locks that block other queries. Keep transactions as short as possible.
+
+**Incorrect (long transaction with external calls):**
+
+```sql
+begin;
+select * from orders where id = 1 for update;  -- Lock acquired
+
+-- Application makes HTTP call to payment API (2-5 seconds)
+-- Other queries on this row are blocked!
+
+update orders set status = 'paid' where id = 1;
+commit;  -- Lock held for entire duration
+```
+
+**Correct (minimal transaction scope):**
+
+```sql
+-- Validate data and call APIs outside transaction
+-- Application: response = await paymentAPI.charge(...)
+
+-- Only hold lock for the actual update
+begin;
+update orders
+set status = 'paid', payment_id = $1
+where id = $2 and status = 'pending'
+returning *;
+commit;  -- Lock held for milliseconds
+```
+
+Use `statement_timeout` to prevent runaway transactions:
+
+```sql
+-- Abort queries running longer than 30 seconds
+set statement_timeout = '30s';
+
+-- Or per-session
+set local statement_timeout = '5s';
+```
+
+Reference: [Transaction Management](https://www.postgresql.org/docs/current/tutorial-transactions.html)

--- a/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
+++ b/skills/supabase-postgres-best-practices/references/lock-skip-locked.md
@@ -1,0 +1,54 @@
+---
+title: Use SKIP LOCKED for Non-Blocking Queue Processing
+impact: MEDIUM-HIGH
+impactDescription: 10x throughput for worker queues
+tags: skip-locked, queue, workers, concurrency
+---
+
+## Use SKIP LOCKED for Non-Blocking Queue Processing
+
+When multiple workers process a queue, SKIP LOCKED allows workers to process different rows without waiting.
+
+**Incorrect (workers block each other):**
+
+```sql
+-- Worker 1 and Worker 2 both try to get next job
+begin;
+select * from jobs where status = 'pending' order by created_at limit 1 for update;
+-- Worker 2 waits for Worker 1's lock to release!
+```
+
+**Correct (SKIP LOCKED for parallel processing):**
+
+```sql
+-- Each worker skips locked rows and gets the next available
+begin;
+select * from jobs
+where status = 'pending'
+order by created_at
+limit 1
+for update skip locked;
+
+-- Worker 1 gets job 1, Worker 2 gets job 2 (no waiting)
+
+update jobs set status = 'processing' where id = $1;
+commit;
+```
+
+Complete queue pattern:
+
+```sql
+-- Atomic claim-and-update in one statement
+update jobs
+set status = 'processing', worker_id = $1, started_at = now()
+where id = (
+  select id from jobs
+  where status = 'pending'
+  order by created_at
+  limit 1
+  for update skip locked
+)
+returning *;
+```
+
+Reference: [SELECT FOR UPDATE SKIP LOCKED](https://www.postgresql.org/docs/current/sql-select.html#SQL-FOR-UPDATE-SHARE)

--- a/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
+++ b/skills/supabase-postgres-best-practices/references/monitor-explain-analyze.md
@@ -1,0 +1,45 @@
+---
+title: Use EXPLAIN ANALYZE to Diagnose Slow Queries
+impact: LOW-MEDIUM
+impactDescription: Identify exact bottlenecks in query execution
+tags: explain, analyze, diagnostics, query-plan
+---
+
+## Use EXPLAIN ANALYZE to Diagnose Slow Queries
+
+EXPLAIN ANALYZE executes the query and shows actual timings, revealing the true performance bottlenecks.
+
+**Incorrect (guessing at performance issues):**
+
+```sql
+-- Query is slow, but why?
+select * from orders where customer_id = 123 and status = 'pending';
+-- "It must be missing an index" - but which one?
+```
+
+**Correct (use EXPLAIN ANALYZE):**
+
+```sql
+explain (analyze, buffers, format text)
+select * from orders where customer_id = 123 and status = 'pending';
+
+-- Output reveals the issue:
+-- Seq Scan on orders (cost=0.00..25000.00 rows=50 width=100) (actual time=0.015..450.123 rows=50 loops=1)
+--   Filter: ((customer_id = 123) AND (status = 'pending'::text))
+--   Rows Removed by Filter: 999950
+--   Buffers: shared hit=5000 read=15000
+-- Planning Time: 0.150 ms
+-- Execution Time: 450.500 ms
+```
+
+Key things to look for:
+
+```sql
+-- Seq Scan on large tables = missing index
+-- Rows Removed by Filter = poor selectivity or missing index
+-- Buffers: read >> hit = data not cached, needs more memory
+-- Nested Loop with high loops = consider different join strategy
+-- Sort Method: external merge = work_mem too low
+```
+
+Reference: [EXPLAIN](https://supabase.com/docs/guides/database/inspect)

--- a/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
+++ b/skills/supabase-postgres-best-practices/references/monitor-pg-stat-statements.md
@@ -1,0 +1,55 @@
+---
+title: Enable pg_stat_statements for Query Analysis
+impact: LOW-MEDIUM
+impactDescription: Identify top resource-consuming queries
+tags: pg-stat-statements, monitoring, statistics, performance
+---
+
+## Enable pg_stat_statements for Query Analysis
+
+pg_stat_statements tracks execution statistics for all queries, helping identify slow and frequent queries.
+
+**Incorrect (no visibility into query patterns):**
+
+```sql
+-- Database is slow, but which queries are the problem?
+-- No way to know without pg_stat_statements
+```
+
+**Correct (enable and query pg_stat_statements):**
+
+```sql
+-- Enable the extension
+create extension if not exists pg_stat_statements;
+
+-- Find slowest queries by total time
+select
+  calls,
+  round(total_exec_time::numeric, 2) as total_time_ms,
+  round(mean_exec_time::numeric, 2) as mean_time_ms,
+  query
+from pg_stat_statements
+order by total_exec_time desc
+limit 10;
+
+-- Find most frequent queries
+select calls, query
+from pg_stat_statements
+order by calls desc
+limit 10;
+
+-- Reset statistics after optimization
+select pg_stat_statements_reset();
+```
+
+Key metrics to monitor:
+
+```sql
+-- Queries with high mean time (candidates for optimization)
+select query, mean_exec_time, calls
+from pg_stat_statements
+where mean_exec_time > 100  -- > 100ms average
+order by mean_exec_time desc;
+```
+
+Reference: [pg_stat_statements](https://supabase.com/docs/guides/database/extensions/pg_stat_statements)

--- a/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
+++ b/skills/supabase-postgres-best-practices/references/monitor-vacuum-analyze.md
@@ -1,0 +1,55 @@
+---
+title: Maintain Table Statistics with VACUUM and ANALYZE
+impact: MEDIUM
+impactDescription: 2-10x better query plans with accurate statistics
+tags: vacuum, analyze, statistics, maintenance, autovacuum
+---
+
+## Maintain Table Statistics with VACUUM and ANALYZE
+
+Outdated statistics cause the query planner to make poor decisions. VACUUM reclaims space, ANALYZE updates statistics.
+
+**Incorrect (stale statistics):**
+
+```sql
+-- Table has 1M rows but stats say 1000
+-- Query planner chooses wrong strategy
+explain select * from orders where status = 'pending';
+-- Shows: Seq Scan (because stats show small table)
+-- Actually: Index Scan would be much faster
+```
+
+**Correct (maintain fresh statistics):**
+
+```sql
+-- Manually analyze after large data changes
+analyze orders;
+
+-- Analyze specific columns used in WHERE clauses
+analyze orders (status, created_at);
+
+-- Check when tables were last analyzed
+select
+  relname,
+  last_vacuum,
+  last_autovacuum,
+  last_analyze,
+  last_autoanalyze
+from pg_stat_user_tables
+order by last_analyze nulls first;
+```
+
+Autovacuum tuning for busy tables:
+
+```sql
+-- Increase frequency for high-churn tables
+alter table orders set (
+  autovacuum_vacuum_scale_factor = 0.05,     -- Vacuum at 5% dead tuples (default 20%)
+  autovacuum_analyze_scale_factor = 0.02     -- Analyze at 2% changes (default 10%)
+);
+
+-- Check autovacuum status
+select * from pg_stat_progress_vacuum;
+```
+
+Reference: [VACUUM](https://supabase.com/docs/guides/database/database-size#vacuum-operations)

--- a/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
+++ b/skills/supabase-postgres-best-practices/references/query-composite-indexes.md
@@ -1,0 +1,44 @@
+---
+title: Create Composite Indexes for Multi-Column Queries
+impact: HIGH
+impactDescription: 5-10x faster multi-column queries
+tags: indexes, composite-index, multi-column, query-optimization
+---
+
+## Create Composite Indexes for Multi-Column Queries
+
+When queries filter on multiple columns, a composite index is more efficient than separate single-column indexes.
+
+**Incorrect (separate indexes require bitmap scan):**
+
+```sql
+-- Two separate indexes
+create index orders_status_idx on orders (status);
+create index orders_created_idx on orders (created_at);
+
+-- Query must combine both indexes (slower)
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Correct (composite index):**
+
+```sql
+-- Single composite index (leftmost column first for equality checks)
+create index orders_status_created_idx on orders (status, created_at);
+
+-- Query uses one efficient index scan
+select * from orders where status = 'pending' and created_at > '2024-01-01';
+```
+
+**Column order matters** - place equality columns first, range columns last:
+
+```sql
+-- Good: status (=) before created_at (>)
+create index idx on orders (status, created_at);
+
+-- Works for: WHERE status = 'pending'
+-- Works for: WHERE status = 'pending' AND created_at > '2024-01-01'
+-- Does NOT work for: WHERE created_at > '2024-01-01' (leftmost prefix rule)
+```
+
+Reference: [Multicolumn Indexes](https://www.postgresql.org/docs/current/indexes-multicolumn.html)

--- a/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
+++ b/skills/supabase-postgres-best-practices/references/query-covering-indexes.md
@@ -1,0 +1,40 @@
+---
+title: Use Covering Indexes to Avoid Table Lookups
+impact: MEDIUM-HIGH
+impactDescription: 2-5x faster queries by eliminating heap fetches
+tags: indexes, covering-index, include, index-only-scan
+---
+
+## Use Covering Indexes to Avoid Table Lookups
+
+Covering indexes include all columns needed by a query, enabling index-only scans that skip the table entirely.
+
+**Incorrect (index scan + heap fetch):**
+
+```sql
+create index users_email_idx on users (email);
+
+-- Must fetch name and created_at from table heap
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+**Correct (index-only scan with INCLUDE):**
+
+```sql
+-- Include non-searchable columns in the index
+create index users_email_idx on users (email) include (name, created_at);
+
+-- All columns served from index, no table access needed
+select email, name, created_at from users where email = 'user@example.com';
+```
+
+Use INCLUDE for columns you SELECT but don't filter on:
+
+```sql
+-- Searching by status, but also need customer_id and total
+create index orders_status_idx on orders (status) include (customer_id, total);
+
+select status, customer_id, total from orders where status = 'shipped';
+```
+
+Reference: [Index-Only Scans](https://www.postgresql.org/docs/current/indexes-index-only-scans.html)

--- a/skills/supabase-postgres-best-practices/references/query-index-types.md
+++ b/skills/supabase-postgres-best-practices/references/query-index-types.md
@@ -1,0 +1,48 @@
+---
+title: Choose the Right Index Type for Your Data
+impact: HIGH
+impactDescription: 10-100x improvement with correct index type
+tags: indexes, btree, gin, gist, brin, hash, index-types
+---
+
+## Choose the Right Index Type for Your Data
+
+Different index types excel at different query patterns. The default B-tree isn't always optimal.
+
+**Incorrect (B-tree for JSONB containment):**
+
+```sql
+-- B-tree cannot optimize containment operators
+create index products_attrs_idx on products (attributes);
+select * from products where attributes @> '{"color": "red"}';
+-- Full table scan - B-tree doesn't support @> operator
+```
+
+**Correct (GIN for JSONB):**
+
+```sql
+-- GIN supports @>, ?, ?&, ?| operators
+create index products_attrs_idx on products using gin (attributes);
+select * from products where attributes @> '{"color": "red"}';
+```
+
+Index type guide:
+
+```sql
+-- B-tree (default): =, <, >, BETWEEN, IN, IS NULL
+create index users_created_idx on users (created_at);
+
+-- GIN: arrays, JSONB, full-text search
+create index posts_tags_idx on posts using gin (tags);
+
+-- GiST: geometric data, range types, nearest-neighbor (KNN) queries
+create index locations_idx on places using gist (location);
+
+-- BRIN: large time-series tables (10-100x smaller)
+create index events_time_idx on events using brin (created_at);
+
+-- Hash: equality-only (slightly faster than B-tree for =)
+create index sessions_token_idx on sessions using hash (token);
+```
+
+Reference: [Index Types](https://www.postgresql.org/docs/current/indexes-types.html)

--- a/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
+++ b/skills/supabase-postgres-best-practices/references/query-missing-indexes.md
@@ -1,0 +1,43 @@
+---
+title: Add Indexes on WHERE and JOIN Columns
+impact: CRITICAL
+impactDescription: 100-1000x faster queries on large tables
+tags: indexes, performance, sequential-scan, query-optimization
+---
+
+## Add Indexes on WHERE and JOIN Columns
+
+Queries filtering or joining on unindexed columns cause full table scans, which become exponentially slower as tables grow.
+
+**Incorrect (sequential scan on large table):**
+
+```sql
+-- No index on customer_id causes full table scan
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Seq Scan on orders (cost=0.00..25000.00 rows=100 width=85)
+```
+
+**Correct (index scan):**
+
+```sql
+-- Create index on frequently filtered column
+create index orders_customer_id_idx on orders (customer_id);
+
+select * from orders where customer_id = 123;
+
+-- EXPLAIN shows: Index Scan using orders_customer_id_idx (cost=0.42..8.44 rows=100 width=85)
+```
+
+For JOIN columns, always index the foreign key side:
+
+```sql
+-- Index the referencing column
+create index orders_customer_id_idx on orders (customer_id);
+
+select c.name, o.total
+from customers c
+join orders o on o.customer_id = c.id;
+```
+
+Reference: [Query Optimization](https://supabase.com/docs/guides/database/query-optimization)

--- a/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
+++ b/skills/supabase-postgres-best-practices/references/query-partial-indexes.md
@@ -1,0 +1,45 @@
+---
+title: Use Partial Indexes for Filtered Queries
+impact: HIGH
+impactDescription: 5-20x smaller indexes, faster writes and queries
+tags: indexes, partial-index, query-optimization, storage
+---
+
+## Use Partial Indexes for Filtered Queries
+
+Partial indexes only include rows matching a WHERE condition, making them smaller and faster when queries consistently filter on the same condition.
+
+**Incorrect (full index includes irrelevant rows):**
+
+```sql
+-- Index includes all rows, even soft-deleted ones
+create index users_email_idx on users (email);
+
+-- Query always filters active users
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+**Correct (partial index matches query filter):**
+
+```sql
+-- Index only includes active users
+create index users_active_email_idx on users (email)
+where deleted_at is null;
+
+-- Query uses the smaller, faster index
+select * from users where email = 'user@example.com' and deleted_at is null;
+```
+
+Common use cases for partial indexes:
+
+```sql
+-- Only pending orders (status rarely changes once completed)
+create index orders_pending_idx on orders (created_at)
+where status = 'pending';
+
+-- Only non-null values
+create index products_sku_idx on products (sku)
+where sku is not null;
+```
+
+Reference: [Partial Indexes](https://www.postgresql.org/docs/current/indexes-partial.html)

--- a/skills/supabase-postgres-best-practices/references/schema-constraints.md
+++ b/skills/supabase-postgres-best-practices/references/schema-constraints.md
@@ -1,0 +1,80 @@
+---
+title: Add Constraints Safely in Migrations
+impact: HIGH
+impactDescription: Prevents migration failures and enables idempotent schema changes
+tags: constraints, migrations, schema, alter-table
+---
+
+## Add Constraints Safely in Migrations
+
+PostgreSQL does not support `ADD CONSTRAINT IF NOT EXISTS`. Migrations using this syntax will fail.
+
+**Incorrect (causes syntax error):**
+
+```sql
+-- ERROR: syntax error at or near "not" (SQLSTATE 42601)
+alter table public.profiles
+add constraint if not exists profiles_birthchart_id_unique unique (birthchart_id);
+```
+
+**Correct (idempotent constraint creation):**
+
+```sql
+-- Use DO block to check before adding
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_unique'
+    and conrelid = 'public.profiles'::regclass
+  ) then
+    alter table public.profiles
+    add constraint profiles_birthchart_id_unique unique (birthchart_id);
+  end if;
+end $$;
+```
+
+For all constraint types:
+
+```sql
+-- Check constraints
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'check_age_positive'
+  ) then
+    alter table users add constraint check_age_positive check (age > 0);
+  end if;
+end $$;
+
+-- Foreign keys
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'profiles_birthchart_id_fkey'
+  ) then
+    alter table profiles
+    add constraint profiles_birthchart_id_fkey
+    foreign key (birthchart_id) references birthcharts(id);
+  end if;
+end $$;
+```
+
+Check if constraint exists:
+
+```sql
+-- Query to check constraint existence
+select conname, contype, pg_get_constraintdef(oid)
+from pg_constraint
+where conrelid = 'public.profiles'::regclass;
+
+-- contype values:
+-- 'p' = PRIMARY KEY
+-- 'f' = FOREIGN KEY
+-- 'u' = UNIQUE
+-- 'c' = CHECK
+```
+
+Reference: [Constraints](https://www.postgresql.org/docs/current/ddl-constraints.html)

--- a/skills/supabase-postgres-best-practices/references/schema-data-types.md
+++ b/skills/supabase-postgres-best-practices/references/schema-data-types.md
@@ -1,0 +1,46 @@
+---
+title: Choose Appropriate Data Types
+impact: HIGH
+impactDescription: 50% storage reduction, faster comparisons
+tags: data-types, schema, storage, performance
+---
+
+## Choose Appropriate Data Types
+
+Using the right data types reduces storage, improves query performance, and prevents bugs.
+
+**Incorrect (wrong data types):**
+
+```sql
+create table users (
+  id int,                    -- Will overflow at 2.1 billion
+  email varchar(255),        -- Unnecessary length limit
+  created_at timestamp,      -- Missing timezone info
+  is_active varchar(5),      -- String for boolean
+  price varchar(20)          -- String for numeric
+);
+```
+
+**Correct (appropriate data types):**
+
+```sql
+create table users (
+  id bigint generated always as identity primary key,  -- 9 quintillion max
+  email text,                     -- No artificial limit, same performance as varchar
+  created_at timestamptz,         -- Always store timezone-aware timestamps
+  is_active boolean default true, -- 1 byte vs variable string length
+  price numeric(10,2)             -- Exact decimal arithmetic
+);
+```
+
+Key guidelines:
+
+```sql
+-- IDs: use bigint, not int (future-proofing)
+-- Strings: use text, not varchar(n) unless constraint needed
+-- Time: use timestamptz, not timestamp
+-- Money: use numeric, not float (precision matters)
+-- Enums: use text with check constraint or create enum type
+```
+
+Reference: [Data Types](https://www.postgresql.org/docs/current/datatype.html)

--- a/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
+++ b/skills/supabase-postgres-best-practices/references/schema-foreign-key-indexes.md
@@ -1,0 +1,59 @@
+---
+title: Index Foreign Key Columns
+impact: HIGH
+impactDescription: 10-100x faster JOINs and CASCADE operations
+tags: foreign-key, indexes, joins, schema
+---
+
+## Index Foreign Key Columns
+
+Postgres does not automatically index foreign key columns. Missing indexes cause slow JOINs and CASCADE operations.
+
+**Incorrect (unindexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- No index on customer_id!
+-- JOINs and ON DELETE CASCADE both require full table scan
+select * from orders where customer_id = 123;  -- Seq Scan
+delete from customers where id = 123;          -- Locks table, scans all orders
+```
+
+**Correct (indexed foreign key):**
+
+```sql
+create table orders (
+  id bigint generated always as identity primary key,
+  customer_id bigint references customers(id) on delete cascade,
+  total numeric(10,2)
+);
+
+-- Always index the FK column
+create index orders_customer_id_idx on orders (customer_id);
+
+-- Now JOINs and cascades are fast
+select * from orders where customer_id = 123;  -- Index Scan
+delete from customers where id = 123;          -- Uses index, fast cascade
+```
+
+Find missing FK indexes:
+
+```sql
+select
+  conrelid::regclass as table_name,
+  a.attname as fk_column
+from pg_constraint c
+join pg_attribute a on a.attrelid = c.conrelid and a.attnum = any(c.conkey)
+where c.contype = 'f'
+  and not exists (
+    select 1 from pg_index i
+    where i.indrelid = c.conrelid and a.attnum = any(i.indkey)
+  );
+```
+
+Reference: [Foreign Keys](https://www.postgresql.org/docs/current/ddl-constraints.html#DDL-CONSTRAINTS-FK)

--- a/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
+++ b/skills/supabase-postgres-best-practices/references/schema-lowercase-identifiers.md
@@ -1,0 +1,55 @@
+---
+title: Use Lowercase Identifiers for Compatibility
+impact: MEDIUM
+impactDescription: Avoid case-sensitivity bugs with tools, ORMs, and AI assistants
+tags: naming, identifiers, case-sensitivity, schema, conventions
+---
+
+## Use Lowercase Identifiers for Compatibility
+
+PostgreSQL folds unquoted identifiers to lowercase. Quoted mixed-case identifiers require quotes forever and cause issues with tools, ORMs, and AI assistants that may not recognize them.
+
+**Incorrect (mixed-case identifiers):**
+
+```sql
+-- Quoted identifiers preserve case but require quotes everywhere
+CREATE TABLE "Users" (
+  "userId" bigint PRIMARY KEY,
+  "firstName" text,
+  "lastName" text
+);
+
+-- Must always quote or queries fail
+SELECT "firstName" FROM "Users" WHERE "userId" = 1;
+
+-- This fails - Users becomes users without quotes
+SELECT firstName FROM Users;
+-- ERROR: relation "users" does not exist
+```
+
+**Correct (lowercase snake_case):**
+
+```sql
+-- Unquoted lowercase identifiers are portable and tool-friendly
+CREATE TABLE users (
+  user_id bigint PRIMARY KEY,
+  first_name text,
+  last_name text
+);
+
+-- Works without quotes, recognized by all tools
+SELECT first_name FROM users WHERE user_id = 1;
+```
+
+Common sources of mixed-case identifiers:
+
+```sql
+-- ORMs often generate quoted camelCase - configure them to use snake_case
+-- Migrations from other databases may preserve original casing
+-- Some GUI tools quote identifiers by default - disable this
+
+-- If stuck with mixed-case, create views as a compatibility layer
+CREATE VIEW users AS SELECT "userId" AS user_id, "firstName" AS first_name FROM "Users";
+```
+
+Reference: [Identifiers and Key Words](https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS)

--- a/skills/supabase-postgres-best-practices/references/schema-partitioning.md
+++ b/skills/supabase-postgres-best-practices/references/schema-partitioning.md
@@ -1,0 +1,55 @@
+---
+title: Partition Large Tables for Better Performance
+impact: MEDIUM-HIGH
+impactDescription: 5-20x faster queries and maintenance on large tables
+tags: partitioning, large-tables, time-series, performance
+---
+
+## Partition Large Tables for Better Performance
+
+Partitioning splits a large table into smaller pieces, improving query performance and maintenance operations.
+
+**Incorrect (single large table):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz,
+  data jsonb
+);
+
+-- 500M rows, queries scan everything
+select * from events where created_at > '2024-01-01';  -- Slow
+vacuum events;  -- Takes hours, locks table
+```
+
+**Correct (partitioned by time range):**
+
+```sql
+create table events (
+  id bigint generated always as identity,
+  created_at timestamptz not null,
+  data jsonb
+) partition by range (created_at);
+
+-- Create partitions for each month
+create table events_2024_01 partition of events
+  for values from ('2024-01-01') to ('2024-02-01');
+
+create table events_2024_02 partition of events
+  for values from ('2024-02-01') to ('2024-03-01');
+
+-- Queries only scan relevant partitions
+select * from events where created_at > '2024-01-15';  -- Only scans events_2024_01+
+
+-- Drop old data instantly
+drop table events_2023_01;  -- Instant vs DELETE taking hours
+```
+
+When to partition:
+
+- Tables > 100M rows
+- Time-series data with date-based queries
+- Need to efficiently drop old data
+
+Reference: [Table Partitioning](https://www.postgresql.org/docs/current/ddl-partitioning.html)

--- a/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
+++ b/skills/supabase-postgres-best-practices/references/schema-primary-keys.md
@@ -1,0 +1,61 @@
+---
+title: Select Optimal Primary Key Strategy
+impact: HIGH
+impactDescription: Better index locality, reduced fragmentation
+tags: primary-key, identity, uuid, serial, schema
+---
+
+## Select Optimal Primary Key Strategy
+
+Primary key choice affects insert performance, index size, and replication
+efficiency.
+
+**Incorrect (problematic PK choices):**
+
+```sql
+-- identity is the SQL-standard approach
+create table users (
+  id serial primary key  -- Works, but IDENTITY is recommended
+);
+
+-- Random UUIDs (v4) cause index fragmentation
+create table orders (
+  id uuid default gen_random_uuid() primary key  -- UUIDv4 = random = scattered inserts
+);
+```
+
+**Correct (optimal PK strategies):**
+
+```sql
+-- Use IDENTITY for sequential IDs (SQL-standard, best for most cases)
+create table users (
+  id bigint generated always as identity primary key
+);
+
+-- For distributed systems needing UUIDs, use UUIDv7 (time-ordered)
+-- Requires pg_uuidv7 extension: create extension pg_uuidv7;
+create table orders (
+  id uuid default uuid_generate_v7() primary key  -- Time-ordered, no fragmentation
+);
+
+-- Alternative: time-prefixed IDs for sortable, distributed IDs (no extension needed)
+create table events (
+  id text default concat(
+    to_char(now() at time zone 'utc', 'YYYYMMDDHH24MISSMS'),
+    gen_random_uuid()::text
+  ) primary key
+);
+```
+
+Guidelines:
+
+- Single database: `bigint identity` (sequential, 8 bytes, SQL-standard)
+- Distributed/exposed IDs: UUIDv7 (requires pg_uuidv7) or ULID (time-ordered, no
+  fragmentation)
+- `serial` works but `identity` is SQL-standard and preferred for new
+  applications
+- Avoid random UUIDs (v4) as primary keys on large tables (causes index
+  fragmentation)
+
+Reference:
+[Identity Columns](https://www.postgresql.org/docs/current/sql-createtable.html#SQL-CREATETABLE-PARMS-GENERATED-IDENTITY)

--- a/skills/supabase-postgres-best-practices/references/security-privileges.md
+++ b/skills/supabase-postgres-best-practices/references/security-privileges.md
@@ -1,0 +1,54 @@
+---
+title: Apply Principle of Least Privilege
+impact: MEDIUM
+impactDescription: Reduced attack surface, better audit trail
+tags: privileges, security, roles, permissions
+---
+
+## Apply Principle of Least Privilege
+
+Grant only the minimum permissions required. Never use superuser for application queries.
+
+**Incorrect (overly broad permissions):**
+
+```sql
+-- Application uses superuser connection
+-- Or grants ALL to application role
+grant all privileges on all tables in schema public to app_user;
+grant all privileges on all sequences in schema public to app_user;
+
+-- Any SQL injection becomes catastrophic
+-- drop table users; cascades to everything
+```
+
+**Correct (minimal, specific grants):**
+
+```sql
+-- Create role with no default privileges
+create role app_readonly nologin;
+
+-- Grant only SELECT on specific tables
+grant usage on schema public to app_readonly;
+grant select on public.products, public.categories to app_readonly;
+
+-- Create role for writes with limited scope
+create role app_writer nologin;
+grant usage on schema public to app_writer;
+grant select, insert, update on public.orders to app_writer;
+grant usage on sequence orders_id_seq to app_writer;
+-- No DELETE permission
+
+-- Login role inherits from these
+create role app_user login password 'xxx';
+grant app_writer to app_user;
+```
+
+Revoke public defaults:
+
+```sql
+-- Revoke default public access
+revoke all on schema public from public;
+revoke all on all tables in schema public from public;
+```
+
+Reference: [Roles and Privileges](https://supabase.com/blog/postgres-roles-and-privileges)

--- a/skills/supabase-postgres-best-practices/references/security-rls-basics.md
+++ b/skills/supabase-postgres-best-practices/references/security-rls-basics.md
@@ -1,0 +1,50 @@
+---
+title: Enable Row Level Security for Multi-Tenant Data
+impact: CRITICAL
+impactDescription: Database-enforced tenant isolation, prevent data leaks
+tags: rls, row-level-security, multi-tenant, security
+---
+
+## Enable Row Level Security for Multi-Tenant Data
+
+Row Level Security (RLS) enforces data access at the database level, ensuring users only see their own data.
+
+**Incorrect (application-level filtering only):**
+
+```sql
+-- Relying only on application to filter
+select * from orders where user_id = $current_user_id;
+
+-- Bug or bypass means all data is exposed!
+select * from orders;  -- Returns ALL orders
+```
+
+**Correct (database-enforced RLS):**
+
+```sql
+-- Enable RLS on the table
+alter table orders enable row level security;
+
+-- Create policy for users to see only their orders
+create policy orders_user_policy on orders
+  for all
+  using (user_id = current_setting('app.current_user_id')::bigint);
+
+-- Force RLS even for table owners
+alter table orders force row level security;
+
+-- Set user context and query
+set app.current_user_id = '123';
+select * from orders;  -- Only returns orders for user 123
+```
+
+Policy for authenticated role:
+
+```sql
+create policy orders_user_policy on orders
+  for all
+  to authenticated
+  using (user_id = auth.uid());
+```
+
+Reference: [Row Level Security](https://supabase.com/docs/guides/database/postgres/row-level-security)

--- a/skills/supabase-postgres-best-practices/references/security-rls-performance.md
+++ b/skills/supabase-postgres-best-practices/references/security-rls-performance.md
@@ -1,0 +1,57 @@
+---
+title: Optimize RLS Policies for Performance
+impact: HIGH
+impactDescription: 5-10x faster RLS queries with proper patterns
+tags: rls, performance, security, optimization
+---
+
+## Optimize RLS Policies for Performance
+
+Poorly written RLS policies can cause severe performance issues. Use subqueries and indexes strategically.
+
+**Incorrect (function called for every row):**
+
+```sql
+create policy orders_policy on orders
+  using (auth.uid() = user_id);  -- auth.uid() called per row!
+
+-- With 1M rows, auth.uid() is called 1M times
+```
+
+**Correct (wrap functions in SELECT):**
+
+```sql
+create policy orders_policy on orders
+  using ((select auth.uid()) = user_id);  -- Called once, cached
+
+-- 100x+ faster on large tables
+```
+
+Use security definer functions for complex checks:
+
+```sql
+-- Create helper function (runs as definer, bypasses RLS)
+create or replace function is_team_member(team_id bigint)
+returns boolean
+language sql
+security definer
+set search_path = ''
+as $$
+  select exists (
+    select 1 from public.team_members
+    where team_id = $1 and user_id = (select auth.uid())
+  );
+$$;
+
+-- Use in policy (indexed lookup, not per-row check)
+create policy team_orders_policy on orders
+  using ((select is_team_member(team_id)));
+```
+
+Always add indexes on columns used in RLS policies:
+
+```sql
+create index orders_user_id_idx on orders (user_id);
+```
+
+Reference: [RLS Performance](https://supabase.com/docs/guides/database/postgres/row-level-security#rls-performance-recommendations)

--- a/skills/supabase/SKILL.md
+++ b/skills/supabase/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: supabase
+description: "Use when doing ANY task involving Supabase. Triggers: Supabase products (Database, Auth, Edge Functions, Realtime, Storage, Vectors, Cron, Queues); client libraries and SSR integrations (supabase-js, @supabase/ssr) in Next.js, React, SvelteKit, Astro, Remix; auth issues (login, logout, sessions, JWT, cookies, getSession, getUser, getClaims, RLS); Supabase CLI or MCP server; schema changes, migrations, security audits, Postgres extensions (pg_graphql, pg_cron, pg_vector)."
+metadata:
+  author: supabase
+  version: "0.1.2"
+---
+
+# Supabase
+
+## Core Principles
+
+**1. Supabase changes frequently — verify against changelog and current docs before implementing.**
+Do not rely on training data for Supabase features. Function signatures, config.toml settings, and API conventions change between versions.
+
+First, fetch `https://supabase.com/changelog.md` (a lightweight summary index — not a heavy pull), scan for `breaking-change` tags relevant to your task, and follow the linked page for any that apply. Then look up the relevant topic using the documentation access methods below.
+
+**2. Verify your work.**
+After implementing any fix, run a test query to confirm the change works. A fix without verification is incomplete.
+
+**3. Recover from errors, don't loop.**
+If an approach fails after 2-3 attempts, stop and reconsider. Try a different method, check documentation, inspect the error more carefully, and review relevant logs when available. Supabase issues are not always solved by retrying the same command, and the answer is not always in the logs, but logs are often worth checking before proceeding.
+
+**4. Exposing tables to the Data API:** Depending on the user's [Data API settings](https://supabase.com/dashboard/project/<ref>/integrations/data_api/settings), newly created tables may not be automatically exposed via the Data (REST) API. If this is the case, `anon` and `authenticated` roles will need to be explicitly granted access.
+
+> Note that this is separate from RLS, which controls which _rows_ are visible once a table is accessible, not whether the table is accessible at all.
+
+When a user reports a SQL-created table is unexpectedly inaccessible, check their Data API settings and whether the roles have been granted access via explicit `GRANT` SQL. When granting public (`anon`/`authenticated`) access, always enable RLS too. See [Exposing a Table to the Data API](https://supabase.com/docs/guides/api/securing-your-api.md) for the full setup workflow.
+
+**5. RLS in exposed schemas.**
+Enable RLS on every table in any exposed schema, which includes `public` by default. This is critical in Supabase because tables in exposed schemas can be reachable through the Data API when the `anon`/`authenticated` roles have access (see [Exposing a Table to the Data API](https://supabase.com/docs/guides/api/securing-your-api.md)). For private schemas, prefer RLS as defense in depth. After enabling RLS, create policies that match the actual access model rather than defaulting every table to the same `auth.uid()` pattern.
+
+**6. Security checklist.**
+When working on any Supabase task that touches auth, RLS, views, storage, or user data, run through this checklist. These are Supabase-specific security traps that silently create vulnerabilities:
+
+- **Auth and session security**
+  - **Never use `user_metadata` claims in JWT-based authorization decisions.** In Supabase, `raw_user_meta_data` is user-editable and can appear in `auth.jwt()`, so it is unsafe for RLS policies or any other authorization logic. Store authorization data in `raw_app_meta_data` / `app_metadata` instead.
+  - **Deleting a user does not invalidate existing access tokens.** Sign out or revoke sessions first, keep JWT expiry short for sensitive apps, and for strict guarantees validate `session_id` against `auth.sessions` on sensitive operations.
+  - **If you use `app_metadata` or `auth.jwt()` for authorization, remember JWT claims are not always fresh until the user's token is refreshed.**
+
+- **API key and client exposure**
+  - **Never expose the `service_role` or secret key in public clients.** Prefer publishable keys for frontend code. Legacy `anon` keys are only for compatibility. In Next.js, any `NEXT_PUBLIC_` env var is sent to the browser.
+
+- **RLS, views, and privileged database code**
+  - **Views bypass RLS by default.** In Postgres 15 and above, use `CREATE VIEW ... WITH (security_invoker = true)`. In older versions of Postgres, protect your views by revoking access from the `anon` and `authenticated` roles, or by putting them in an unexposed schema.
+  - **UPDATE requires a SELECT policy.** In Postgres RLS, an UPDATE needs to first SELECT the row. Without a SELECT policy, updates silently return 0 rows — no error, just no change.
+  - **Do not put `security definer` functions in an exposed schema.** Keep them in a private or otherwise unexposed schema.
+
+- **Storage access control**
+  - **Storage upsert requires INSERT + SELECT + UPDATE.** Granting only INSERT allows new uploads but file replacement (upsert) silently fails. You need all three.
+
+For any security concern not covered above, fetch the Supabase product security index: `https://supabase.com/docs/guides/security/product-security.md`
+
+## Supabase CLI
+
+Always discover commands via `--help` — never guess. The CLI structure changes between versions.
+
+```bash
+supabase --help                    # All top-level commands
+supabase <group> --help            # Subcommands (e.g., supabase db --help)
+supabase <group> <command> --help  # Flags for a specific command
+```
+
+**Supabase CLI Known gotchas:**
+
+- `supabase db query` requires **CLI v2.79.0+** → use MCP `execute_sql` or `psql` as fallback
+- `supabase db advisors` requires **CLI v2.81.3+** → use MCP `get_advisors` as fallback
+- When you need a new migration SQL file, **always** create it with `supabase migration new <name>` first. Never invent a migration filename or rely on memory for the expected format.
+
+**Version check and upgrade:** Run `supabase --version` to check. For CLI changelogs and version-specific features, consult the [CLI documentation](https://supabase.com/docs/reference/cli/introduction) or [GitHub releases](https://github.com/supabase/cli/releases).
+
+## Supabase MCP Server
+
+For setup instructions, server URL, and configuration, see the [MCP setup guide](https://supabase.com/docs/guides/getting-started/mcp).
+
+**Troubleshooting connection issues** — follow these steps in order:
+
+1. **Check if the server is reachable:**
+   `curl -so /dev/null -w "%{http_code}" https://mcp.supabase.com/mcp`
+   A `401` is expected (no token) and means the server is up. Timeout or "connection refused" means it may be down.
+
+2. **Check `.mcp.json` configuration:**
+   Verify the project root has a valid `.mcp.json` with the correct server URL. If missing, create one pointing to `https://mcp.supabase.com/mcp`.
+
+3. **Authenticate the MCP server:**
+   If the server is reachable and `.mcp.json` is correct but tools aren't visible, the user needs to authenticate. The Supabase MCP server uses OAuth 2.1 — tell the user to trigger the auth flow in their agent, complete it in the browser, and reload the session.
+
+## Supabase Documentation
+
+Before implementing any Supabase feature, find the relevant documentation. Use these methods in priority order:
+
+1. **MCP `search_docs` tool** (preferred — returns relevant snippets directly)
+2. **Fetch docs pages as markdown** — any docs page can be fetched by appending `.md` to the URL path.
+3. **Web search** for Supabase-specific topics when you don't know which page to look at.
+
+## Making and Committing Schema Changes
+
+**To make schema changes, use `execute_sql` (MCP) or `supabase db query` (CLI).** These run SQL directly on the database without creating migration history entries, so you can iterate freely and generate a clean migration when ready.
+
+Do NOT use `apply_migration` to change a local database schema — it writes a migration history entry on every call, which means you can't iterate, and `supabase db diff` / `supabase db pull` will produce empty or conflicting diffs. If you use it, you'll be stuck with whatever SQL you passed on the first try.
+
+**When ready to commit** your changes to a migration file:
+
+1. **Run advisors** → `supabase db advisors` (CLI v2.81.3+) or MCP `get_advisors`. Fix any issues.
+2. **Review the Security Checklist above** if your changes involve views, functions, triggers, or storage.
+3. **Generate the migration** → `supabase db pull <descriptive-name> --local --yes`
+4. **Verify** → `supabase migration list --local`
+
+## Reference Guides
+
+- **Skill Feedback** → [references/skill-feedback.md](references/skill-feedback.md)
+  **MUST read when** the user reports that this skill gave incorrect guidance or is missing information.

--- a/skills/supabase/assets/feedback-issue-template.md
+++ b/skills/supabase/assets/feedback-issue-template.md
@@ -1,0 +1,17 @@
+## What happened
+
+**Task:** <!-- e.g., "Set up MFA on patient records" -->
+
+**Skill said:** <!-- e.g., "Use auth.jwt()->'app_metadata' in the RLS policy" -->
+
+**Expected:** <!-- e.g., "The function also needs SECURITY DEFINER + grant to supabase_auth_admin" -->
+
+## Source
+
+**File:** <!-- e.g., references/security-model.md -->
+
+**Section:** <!-- e.g., "Trust Boundaries > user_metadata vs app_metadata" -->
+
+## Fix suggestion
+
+<!-- Leave blank if unsure -->

--- a/skills/supabase/references/skill-feedback.md
+++ b/skills/supabase/references/skill-feedback.md
@@ -1,0 +1,17 @@
+# Skill Feedback
+
+Use this when the user reports that the skill gave incorrect guidance, is missing information, or could be improved. This is about the skill (agent instructions), not about Supabase the product.
+
+## Steps
+
+1. **Ask permission** — Ask the user if they'd like to submit feedback to the skill maintainers. If they decline, move on.
+
+2. **Draft the issue** — Use the template at [assets/feedback-issue-template.md](../assets/feedback-issue-template.md) to structure the feedback. Fill in the fields based on the conversation. Always identify which specific reference file and section caused the problem.
+
+3. **Submit** — Create a GitHub Issue on the `supabase/agent-skills` repository using the draft as the issue body. The title must follow this format: `user-feedback: <summary of the problem>`.
+
+4. **Share the result** — Share the issue URL with the user after submission. If submission fails, give the user this link to create the issue manually:
+
+```
+https://github.com/supabase/agent-skills/issues/new
+```

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "@opencode-ai/plugin";
 
 import { createServerLogWriter, createSupabaseLogger } from "../shared/log.ts";
 import { createSupabaseAuth } from "./auth.ts";
+import { registerSupabaseSkillPaths } from "./skills.ts";
 import { createSupabaseTools } from "./tools.ts";
 
 const server: Plugin = async (input, options) => {
@@ -10,6 +11,11 @@ const server: Plugin = async (input, options) => {
   });
 
   return {
+    config: async (config) => {
+      registerSupabaseSkillPaths(config, options, {
+        warn: (message, data) => logger.warn(message, data as Record<string, unknown>),
+      });
+    },
     auth: createSupabaseAuth(input, options, { logger }),
     tool: createSupabaseTools(input, options, { logger }),
   };

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,7 +13,7 @@ const server: Plugin = async (input, options) => {
   return {
     config: async (config) => {
       registerSupabaseSkillPaths(config, options, {
-        warn: (message, data) => logger.warn(message, data as Record<string, unknown>),
+        warn: logger.warn,
       });
     },
     auth: createSupabaseAuth(input, options, { logger }),

--- a/src/server/skills.ts
+++ b/src/server/skills.ts
@@ -8,7 +8,7 @@ export const BUNDLED_SUPABASE_SKILLS = [
 
 export type BundledSupabaseSkill = (typeof BUNDLED_SUPABASE_SKILLS)[number];
 
-type Warn = (message: string, data?: unknown) => void;
+type Warn = (message: string, data?: Record<string, unknown>) => unknown;
 
 type ResolverDeps = {
   warn?: Warn;
@@ -21,9 +21,13 @@ type RegisterDeps = ResolverDeps & {
 
 type ConfigWithSkills = object & {
   skills?: {
-    paths?: string[];
-  };
+    paths?: unknown;
+  } | false;
 };
+
+type SkillsConfig = {
+  paths?: unknown;
+} & Record<string, unknown>;
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -31,7 +35,7 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function pluginSkillsOption(options: unknown) {
   if (!isRecord(options) || !("skills" in options)) return true;
-  return options.skills;
+  return (options as { skills?: unknown }).skills;
 }
 
 export function resolveEnabledSupabaseSkills(options: unknown, deps: ResolverDeps = {}) {
@@ -48,6 +52,13 @@ export function resolveEnabledSupabaseSkills(options: unknown, deps: ResolverDep
   for (const key of Object.keys(value)) {
     if (!known.has(key)) {
       deps.warn?.("unknown Supabase bundled skill option ignored", { skill: key });
+      continue;
+    }
+    if (value[key] !== undefined && typeof value[key] !== "boolean") {
+      deps.warn?.("invalid Supabase bundled skill option value", {
+        skill: key,
+        value: value[key] as unknown,
+      });
     }
   }
 
@@ -67,9 +78,24 @@ export function registerSupabaseSkillPaths(
   const skillsRoot = deps.skillsRoot ?? defaultSkillsRoot();
   const exists = deps.exists ?? fs.existsSync;
   const enabled = resolveEnabledSupabaseSkills(options, deps);
+  const skillsConfig: SkillsConfig = isRecord(configWithSkills.skills)
+    ? (configWithSkills.skills as SkillsConfig)
+    : {};
 
-  configWithSkills.skills = configWithSkills.skills ?? {};
-  configWithSkills.skills.paths = configWithSkills.skills.paths ?? [];
+  if (!isRecord(configWithSkills.skills)) {
+    configWithSkills.skills = skillsConfig;
+  }
+
+  if (!Array.isArray(skillsConfig.paths)) {
+    if (skillsConfig.paths !== undefined) {
+      deps.warn?.("invalid Supabase skills.paths value; resetting to array", {
+        value: skillsConfig.paths as unknown,
+      });
+    }
+    skillsConfig.paths = [];
+  }
+
+  const paths = skillsConfig.paths as string[];
 
   for (const skill of enabled) {
     const skillPath = path.join(skillsRoot, skill);
@@ -77,8 +103,9 @@ export function registerSupabaseSkillPaths(
       deps.warn?.("bundled Supabase skill directory not found", { skill, path: skillPath });
       continue;
     }
-    if (!configWithSkills.skills.paths.includes(skillPath)) {
-      configWithSkills.skills.paths.push(skillPath);
+
+    if (!paths.includes(skillPath)) {
+      paths.push(skillPath);
     }
   }
 }

--- a/src/server/skills.ts
+++ b/src/server/skills.ts
@@ -1,5 +1,6 @@
 import fs from "node:fs";
 import path from "node:path";
+import { fileURLToPath } from "node:url";
 
 export const BUNDLED_SUPABASE_SKILLS = [
   "supabase",
@@ -22,7 +23,7 @@ type RegisterDeps = ResolverDeps & {
 type ConfigWithSkills = object & {
   skills?: {
     paths?: unknown;
-  } | false;
+  };
 };
 
 type SkillsConfig = {
@@ -66,7 +67,7 @@ export function resolveEnabledSupabaseSkills(options: unknown, deps: ResolverDep
 }
 
 export function defaultSkillsRoot() {
-  return path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../skills");
+  return path.resolve(path.dirname(fileURLToPath(import.meta.url)), "../../skills");
 }
 
 export function registerSupabaseSkillPaths(
@@ -78,19 +79,26 @@ export function registerSupabaseSkillPaths(
   const skillsRoot = deps.skillsRoot ?? defaultSkillsRoot();
   const exists = deps.exists ?? fs.existsSync;
   const enabled = resolveEnabledSupabaseSkills(options, deps);
-  const skillsConfig: SkillsConfig = isRecord(configWithSkills.skills)
-    ? (configWithSkills.skills as SkillsConfig)
-    : {};
+  let skillsConfig: SkillsConfig;
 
-  if (!isRecord(configWithSkills.skills)) {
+  if (configWithSkills.skills === undefined) {
+    skillsConfig = {};
     configWithSkills.skills = skillsConfig;
+  } else if (isRecord(configWithSkills.skills)) {
+    skillsConfig = configWithSkills.skills as SkillsConfig;
+  } else {
+    deps.warn?.("invalid Supabase skills config; leaving unchanged", {
+      value: configWithSkills.skills as unknown,
+    });
+    return;
   }
 
   if (!Array.isArray(skillsConfig.paths)) {
     if (skillsConfig.paths !== undefined) {
-      deps.warn?.("invalid Supabase skills.paths value; resetting to array", {
+      deps.warn?.("invalid Supabase skills.paths value; leaving unchanged", {
         value: skillsConfig.paths as unknown,
       });
+      return;
     }
     skillsConfig.paths = [];
   }

--- a/src/server/skills.ts
+++ b/src/server/skills.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+
+export const BUNDLED_SUPABASE_SKILLS = [
+  "supabase",
+  "supabase-postgres-best-practices",
+] as const;
+
+export type BundledSupabaseSkill = (typeof BUNDLED_SUPABASE_SKILLS)[number];
+
+type Warn = (message: string, data?: unknown) => void;
+
+type ResolverDeps = {
+  warn?: Warn;
+};
+
+type RegisterDeps = ResolverDeps & {
+  skillsRoot?: string;
+  exists?: (path: string) => boolean;
+};
+
+type ConfigWithSkills = object & {
+  skills?: {
+    paths?: string[];
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function pluginSkillsOption(options: unknown) {
+  if (!isRecord(options) || !("skills" in options)) return true;
+  return options.skills;
+}
+
+export function resolveEnabledSupabaseSkills(options: unknown, deps: ResolverDeps = {}) {
+  const value = pluginSkillsOption(options);
+  if (value === false) return [];
+  if (value === true || value === undefined) return [...BUNDLED_SUPABASE_SKILLS];
+
+  if (!isRecord(value)) {
+    deps.warn?.("invalid Supabase skills option; loading bundled skills", { value });
+    return [...BUNDLED_SUPABASE_SKILLS];
+  }
+
+  const known = new Set<string>(BUNDLED_SUPABASE_SKILLS);
+  for (const key of Object.keys(value)) {
+    if (!known.has(key)) {
+      deps.warn?.("unknown Supabase bundled skill option ignored", { skill: key });
+    }
+  }
+
+  return BUNDLED_SUPABASE_SKILLS.filter((skill) => value[skill] !== false);
+}
+
+export function defaultSkillsRoot() {
+  return path.resolve(path.dirname(new URL(import.meta.url).pathname), "../../skills");
+}
+
+export function registerSupabaseSkillPaths(
+  config: object,
+  options: unknown,
+  deps: RegisterDeps = {},
+) {
+  const configWithSkills = config as ConfigWithSkills;
+  const skillsRoot = deps.skillsRoot ?? defaultSkillsRoot();
+  const exists = deps.exists ?? fs.existsSync;
+  const enabled = resolveEnabledSupabaseSkills(options, deps);
+
+  configWithSkills.skills = configWithSkills.skills ?? {};
+  configWithSkills.skills.paths = configWithSkills.skills.paths ?? [];
+
+  for (const skill of enabled) {
+    const skillPath = path.join(skillsRoot, skill);
+    if (!exists(skillPath)) {
+      deps.warn?.("bundled Supabase skill directory not found", { skill, path: skillPath });
+      continue;
+    }
+    if (!configWithSkills.skills.paths.includes(skillPath)) {
+      configWithSkills.skills.paths.push(skillPath);
+    }
+  }
+}

--- a/test/server-skills.test.ts
+++ b/test/server-skills.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, test } from "bun:test";
+import {
+  registerSupabaseSkillPaths,
+  resolveEnabledSupabaseSkills,
+} from "../src/server/skills.ts";
+
+describe("resolveEnabledSupabaseSkills", () => {
+  test("enables all bundled skills by default", () => {
+    expect(resolveEnabledSupabaseSkills(undefined)).toEqual([
+      "supabase",
+      "supabase-postgres-best-practices",
+    ]);
+  });
+
+  test("disables all skills when skills is false", () => {
+    expect(resolveEnabledSupabaseSkills({ skills: false })).toEqual([]);
+  });
+
+  test("keeps omitted skill keys enabled", () => {
+    expect(resolveEnabledSupabaseSkills({ skills: { "supabase-postgres-best-practices": false } })).toEqual([
+      "supabase",
+    ]);
+  });
+
+  test("warns and ignores unknown skill keys", () => {
+    const warnings: unknown[] = [];
+    expect(resolveEnabledSupabaseSkills({ skills: { typo: false } }, { warn: (_message, data) => warnings.push(data) })).toEqual([
+      "supabase",
+      "supabase-postgres-best-practices",
+    ]);
+    expect(warnings).toHaveLength(1);
+  });
+});
+
+describe("registerSupabaseSkillPaths", () => {
+  test("adds selected skill directories", () => {
+    const config: { skills?: { paths?: string[] } } = {};
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: () => true,
+    });
+    expect(config.skills?.paths).toEqual([
+      "/plugin/skills/supabase",
+      "/plugin/skills/supabase-postgres-best-practices",
+    ]);
+  });
+
+  test("does not add duplicate paths", () => {
+    const config = { skills: { paths: ["/plugin/skills/supabase"] } };
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: () => true,
+    });
+    expect(config.skills.paths).toEqual([
+      "/plugin/skills/supabase",
+      "/plugin/skills/supabase-postgres-best-practices",
+    ]);
+  });
+
+  test("warns and skips missing directories", () => {
+    const warnings: unknown[] = [];
+    const config: { skills?: { paths?: string[] } } = {};
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: (path) => !path.endsWith("postgres-best-practices"),
+      warn: (_message, data) => warnings.push(data),
+    });
+    expect(config.skills?.paths).toEqual(["/plugin/skills/supabase"]);
+    expect(warnings).toHaveLength(1);
+  });
+});

--- a/test/server-skills.test.ts
+++ b/test/server-skills.test.ts
@@ -30,6 +30,15 @@ describe("resolveEnabledSupabaseSkills", () => {
     ]);
     expect(warnings).toHaveLength(1);
   });
+
+  test("warns on non-boolean known skill values", () => {
+    const warnings: unknown[] = [];
+    expect(resolveEnabledSupabaseSkills({ skills: { supabase: "yes" } }, { warn: (_message, data) => warnings.push(data) })).toEqual([
+      "supabase",
+      "supabase-postgres-best-practices",
+    ]);
+    expect(warnings).toHaveLength(1);
+  });
 });
 
 describe("registerSupabaseSkillPaths", () => {
@@ -66,6 +75,36 @@ describe("registerSupabaseSkillPaths", () => {
       warn: (_message, data) => warnings.push(data),
     });
     expect(config.skills?.paths).toEqual(["/plugin/skills/supabase"]);
+    expect(warnings).toHaveLength(1);
+  });
+
+  test("replaces disabled skills config with paths array", () => {
+    const config: { skills?: { paths?: string[] } | false } = { skills: false };
+
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: () => true,
+    });
+
+    expect(config.skills).toEqual({
+      paths: ["/plugin/skills/supabase", "/plugin/skills/supabase-postgres-best-practices"],
+    });
+  });
+
+  test("replaces malformed paths with a fresh array", () => {
+    const warnings: unknown[] = [];
+    const config = { skills: { paths: "nope" as unknown as string[] } };
+
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: () => true,
+      warn: (_message, data) => warnings.push(data),
+    });
+
+    expect(config.skills.paths).toEqual([
+      "/plugin/skills/supabase",
+      "/plugin/skills/supabase-postgres-best-practices",
+    ]);
     expect(warnings).toHaveLength(1);
   });
 });

--- a/test/server-skills.test.ts
+++ b/test/server-skills.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test";
+import path from "node:path";
+import serverModule from "../src/server/index.ts";
 import {
+  defaultSkillsRoot,
   registerSupabaseSkillPaths,
   resolveEnabledSupabaseSkills,
 } from "../src/server/skills.ts";
@@ -127,5 +130,44 @@ describe("registerSupabaseSkillPaths", () => {
 
     expect(config.skills.paths).toBe("nope");
     expect(warnings).toHaveLength(1);
+  });
+});
+
+describe("server config hook", () => {
+  test("registers bundled skill paths", async () => {
+    const hooks = await serverModule.server(
+      {
+        client: {
+          app: {
+            log: () => Promise.resolve(true),
+          },
+        },
+        directory: "/workspace",
+        worktree: "/workspace",
+        serverUrl: new URL("http://localhost:4096"),
+        project: {},
+        $: {},
+      } as never,
+      undefined,
+    );
+
+    const config = {
+      skills: {
+        paths: ["/user/skills"],
+        urls: ["https://example.com/.well-known/skills/"],
+      },
+    };
+
+    await hooks.config?.(config as never);
+
+    const skillsRoot = defaultSkillsRoot();
+    expect(config.skills).toEqual({
+      paths: [
+        "/user/skills",
+        path.join(skillsRoot, "supabase"),
+        path.join(skillsRoot, "supabase-postgres-best-practices"),
+      ],
+      urls: ["https://example.com/.well-known/skills/"],
+    });
   });
 });

--- a/test/server-skills.test.ts
+++ b/test/server-skills.test.ts
@@ -66,6 +66,29 @@ describe("registerSupabaseSkillPaths", () => {
     ]);
   });
 
+  test("preserves existing paths and urls", () => {
+    const config = {
+      skills: {
+        paths: ["/user/skills"],
+        urls: ["https://example.com/.well-known/skills/"],
+      },
+    };
+
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: () => true,
+    });
+
+    expect(config.skills).toEqual({
+      paths: [
+        "/user/skills",
+        "/plugin/skills/supabase",
+        "/plugin/skills/supabase-postgres-best-practices",
+      ],
+      urls: ["https://example.com/.well-known/skills/"],
+    });
+  });
+
   test("warns and skips missing directories", () => {
     const warnings: unknown[] = [];
     const config: { skills?: { paths?: string[] } } = {};
@@ -78,22 +101,9 @@ describe("registerSupabaseSkillPaths", () => {
     expect(warnings).toHaveLength(1);
   });
 
-  test("replaces disabled skills config with paths array", () => {
-    const config: { skills?: { paths?: string[] } | false } = { skills: false };
-
-    registerSupabaseSkillPaths(config, undefined, {
-      skillsRoot: "/plugin/skills",
-      exists: () => true,
-    });
-
-    expect(config.skills).toEqual({
-      paths: ["/plugin/skills/supabase", "/plugin/skills/supabase-postgres-best-practices"],
-    });
-  });
-
-  test("replaces malformed paths with a fresh array", () => {
+  test("skips non-object skills config without mutation", () => {
     const warnings: unknown[] = [];
-    const config = { skills: { paths: "nope" as unknown as string[] } };
+    const config: { skills?: unknown } = { skills: false };
 
     registerSupabaseSkillPaths(config, undefined, {
       skillsRoot: "/plugin/skills",
@@ -101,10 +111,21 @@ describe("registerSupabaseSkillPaths", () => {
       warn: (_message, data) => warnings.push(data),
     });
 
-    expect(config.skills.paths).toEqual([
-      "/plugin/skills/supabase",
-      "/plugin/skills/supabase-postgres-best-practices",
-    ]);
+    expect(config.skills).toBe(false);
+    expect(warnings).toHaveLength(1);
+  });
+
+  test("skips malformed paths without mutation", () => {
+    const warnings: unknown[] = [];
+    const config = { skills: { paths: "nope" as unknown } };
+
+    registerSupabaseSkillPaths(config, undefined, {
+      skillsRoot: "/plugin/skills",
+      exists: () => true,
+      warn: (_message, data) => warnings.push(data),
+    });
+
+    expect(config.skills.paths).toBe("nope");
     expect(warnings).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## Summary
- Vendor official Supabase agent skills and include them in published packages.
- Register bundled skill directories by default via the plugin config hook, with opt-out and per-skill selection.
- Add maintainer sync script, resolver tests, docs, and follow-up issue for automatic sync.

## Verification
- `bun run typecheck` passes
- `bun test test/server-skills.test.ts` passes
- `bun run verify:pack` includes bundled skills

## Notes
- Full `bun test` is blocked by existing `@opentui/solid` JSX runtime export errors in TUI/plugin export tests.
- `bun run skills:sync` is blocked until `supabase/agent-skills` publishes GitHub release assets.

Refs #46