### PR TITLE
fix: harden Supabase auth refresh races

### DIFF
--- a/.changeset/2026-05-08-1140-auth-refresh-race.md
+++ b/.changeset/2026-05-08-1140-auth-refresh-race.md
@@ -1,0 +1,5 @@
+---
+"opencode-supabase": patch
+---
+
+Prevent ambiguous broker refresh errors from clearing saved Supabase auth.

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -337,7 +337,7 @@ export async function ensureSupabaseToolAuth(
       await writeSavedAuth(input, nextAuth);
       return nextAuth;
     } catch (error) {
-      if (error instanceof BrokerClientError && (error.status === 401 || error.status === 400)) {
+      if (error instanceof BrokerClientError) {
         const latest = await readSavedAuth(input);
         if (!isSameAuth(latest.auth, current.auth)) {
           if (latest.auth) {
@@ -346,14 +346,14 @@ export async function ensureSupabaseToolAuth(
           throw new Error(NOT_CONNECTED_MESSAGE);
         }
 
-        await clearSavedAuth(input);
-        try {
-          await clearHostAuth(input, fetchImpl);
-        } catch {}
-        throw new Error(NOT_CONNECTED_MESSAGE);
-      }
+        if (error.code === "unauthorized") {
+          await clearSavedAuth(input);
+          try {
+            await clearHostAuth(input, fetchImpl);
+          } catch {}
+          throw new Error(NOT_CONNECTED_MESSAGE);
+        }
 
-      if (error instanceof BrokerClientError) {
         throw new Error(`Supabase auth refresh failed: ${error.message}`);
       }
       throw error;
@@ -366,7 +366,7 @@ export async function ensureSupabaseToolAuth(
     })
     .finally(() => {
       if (inFlightRefreshes.get(refreshKey)?.promise === refreshEntry.promise) {
-      inFlightRefreshes.delete(refreshKey);
+        inFlightRefreshes.delete(refreshKey);
       }
     });
 

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -144,7 +144,7 @@ describe("server auth hook", () => {
           new Response(
             JSON.stringify({
               error: {
-                code: "invalid_grant",
+                code: "unauthorized",
                 message: "Refresh token expired",
               },
             }),

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -891,6 +891,53 @@ describe("server tools auth helper", () => {
     expect(hostClearFetch).not.toHaveBeenCalled();
   });
 
+  test("ambiguous broker refresh errors do not clear saved auth", async () => {
+    const { input } = await createInput();
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    const savedAuth = {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    };
+    await writeSavedAuth(input, savedAuth);
+
+    const hostClearFetch: FetchLike = mock(async () => new Response(null, { status: 204 }));
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        expect(init?.method).toBe("POST");
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "invalid_request",
+              message: "broker rejected malformed refresh request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      return hostClearFetch(request, init);
+    });
+
+    await expect(
+      ensureSupabaseToolAuth(
+        input,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17686,
+        },
+        { fetch: fetchMock },
+      ),
+    ).rejects.toThrow("Supabase auth refresh failed: broker rejected malformed refresh request");
+
+    await expect(readSavedAuth(input)).resolves.toEqual({ version: 1, auth: savedAuth });
+    expect(hostClearFetch).not.toHaveBeenCalled();
+  });
+
   test("shared stale refresh rejection clears host auth for each joined directory", async () => {
     const root = await mkdtemp(join(tmpdir(), "opencode-supabase-tools-"));
     cleanupPaths.push(root);
@@ -930,8 +977,10 @@ describe("server tools auth helper", () => {
         brokerRefreshCalls += 1;
         return new Response(
           JSON.stringify({
-            error: "unauthorized",
-            message: "upstream token request was rejected",
+            error: {
+              code: "unauthorized",
+              message: "upstream token request was rejected",
+            },
           }),
           {
             status: 401,


### PR DESCRIPTION
## Summary
- Preserve saved auth on ambiguous broker refresh errors instead of clearing on raw 400/401 status
- Continue clearing auth only for explicit broker unauthorized errors
- Add regression coverage for ambiguous refresh errors preserving local auth

## Test Plan
- [x] bun test --preload @opentui/solid/preload
- [x] bun run typecheck
- [x] bun run lint

Closes #33