### PR TITLE
fix: recover corrupt Supabase auth store instead of crashing

### DIFF
--- a/.changeset/2026-05-12-corrupt-auth-store.md
+++ b/.changeset/2026-05-12-corrupt-auth-store.md
@@ -1,0 +1,5 @@
+---
+"opencode-supabase": patch
+---
+
+Recover corrupt Supabase auth store instead of crashing. Invalid or unsupported store files are backed up, reset to a valid notice state, and surfaced through the `/supabase` dialog and tool errors.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,15 @@ For Supabase Management API work, prefer the markdownized docs:
 
 Use this reference when implementing or reviewing authenticated Supabase API tools.
 
+## Test Commands
+
+Never run raw `bun test` for repository verification. Always use package scripts so required preloads run.
+
+- Use `bun run test` for all test suites.
+- Use `bun run test <test-file>` for focused tests.
+- Do not use `bun test <test-file>` directly. It skips `@opentui/solid/preload` and can produce false `jsxDEV` / `jsx-runtime.d.ts` failures for TUI/TSX tests.
+- When comparing with CI, mirror `.github/workflows/ci.yml`: `bun run lint`, `bun run typecheck`, `bun run test`, `bun run verify:pack`.
+
 ## Bundled Supabase Skills
 
 `skills/` contains real vendored files synced from `supabase/agent-skills` at a pinned commit.

--- a/docs/superpowers/plans/2026-05-11-corrupt-auth-store.md
+++ b/docs/superpowers/plans/2026-05-11-corrupt-auth-store.md
@@ -1,0 +1,1074 @@
+# Corrupt Supabase Auth Store Recovery Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make corrupted Supabase auth stores recover gracefully with backups, reset state, durable reconnect dialogs, and clear tool errors.
+
+**Architecture:** Keep persisted-state validation and corruption recovery in `src/server/store.ts`, where the auth-store format is owned. Surface persisted `auth_store_reset` notices through `src/server/tools.ts` and `src/server/auth.ts`, then let `src/tui/dialog.tsx` render a durable confirm dialog that starts OAuth reconnect.
+
+**Tech Stack:** TypeScript, Bun, Bun test runner, OpenCode plugin server/TUI APIs, Solid signal state.
+
+---
+
+## Worktree Setup
+
+Run this from `/home/jumski/Code/jumski/opencode-supabase` before implementation:
+
+```bash
+git fetch origin
+git worktree add -b issue-34-corrupt-auth-store .worktrees/issue-34-corrupt-auth-store origin/main
+```
+
+Use this workdir for every implementation command:
+
+```bash
+/home/jumski/Code/jumski/opencode-supabase/.worktrees/issue-34-corrupt-auth-store
+```
+
+## File Structure
+
+- Modify: `src/server/store.ts`
+  - own persisted-state validation, backup, reset, `auth_store_reset` notice type, notice writes, and logger-aware recovery
+- Modify: `src/server/tools.ts`
+  - format corruption notices for tool-call errors, pass logger/timestamp deps to store reads, include notices in auth status, and preserve PR #51 refresh-race semantics unchanged
+- Modify: `src/server/auth.ts`
+  - include optional corruption notice data in status instructions
+- Modify: `src/tui/dialog.tsx`
+  - parse corruption notice data, add notice state, and render persistent reconnect dialog
+- Modify: `test/server-store.test.ts`
+  - cover invalid JSON, wrong version, wrong shape, backup contents, notice clearing, and deterministic backup names
+- Modify: `test/server-tools.test.ts`
+  - cover tool-call corruption discovery and reconnect error text
+- Modify: `test/server-auth.test.ts`
+  - cover status instructions that include persisted corruption notices
+- Modify: `test/plugin-exports.test.ts`
+  - cover `/supabase` preflight and dialog rendering for corruption notices
+
+## Task 1: Store Validation, Backup, Reset, And Notice
+
+**Files:**
+- Modify: `src/server/store.ts`
+- Test: `test/server-store.test.ts`
+
+- [ ] **Step 1: Write failing store recovery tests**
+
+Update the imports in `test/server-store.test.ts`:
+
+```ts
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+```
+
+Add `writeSavedAuthNotice` to the existing store import:
+
+```ts
+import {
+  clearSavedAuth,
+  getStoreFile,
+  readSavedAuth,
+  writeSavedAuth,
+  writeSavedAuthNotice,
+} from "../src/server/store.ts";
+```
+
+Add this helper after `createInput()`:
+
+```ts
+async function writeRawStore(input: PluginLikeInput, contents: string) {
+  const path = getStoreFile(input);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents);
+  return path;
+}
+```
+
+Add these tests inside `describe("server auth store", () => { ... })`:
+
+```ts
+test("backs up invalid JSON and resets the auth store with a notice", async () => {
+  const input = await createInput();
+  const path = await writeRawStore(input, "{ not json");
+  const warn = mock(async () => undefined);
+  const backupPath = join(
+    input.worktree,
+    ".opencode",
+    "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+  );
+
+  await expect(
+    readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+      logger: { warn },
+    }),
+  ).resolves.toEqual({
+    version: 1,
+    notice: {
+      type: "auth_store_reset",
+      message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+      backupPath,
+    },
+  });
+
+  await expect(readFile(path, "utf8")).resolves.toContain("auth_store_reset");
+  await expect(readFile(backupPath, "utf8")).resolves.toBe("{ not json");
+  expect(warn).toHaveBeenCalledTimes(1);
+});
+
+test("backs up an unsupported store version and resets the auth store", async () => {
+  const input = await createInput();
+  await writeRawStore(input, JSON.stringify({ version: 2, auth: { access: "a", refresh: "r", expires: 1 } }));
+
+  const state = await readSavedAuth(input, {
+    now: () => new Date("2026-05-11T10:20:30.000Z"),
+  });
+
+  expect(state).toMatchObject({
+    version: 1,
+    notice: {
+      type: "auth_store_reset",
+      backupPath: join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json"),
+    },
+  });
+});
+
+test("backs up a wrong top-level shape and resets the auth store", async () => {
+  const input = await createInput();
+  await writeRawStore(input, JSON.stringify(["not", "an", "object"]));
+
+  await expect(
+    readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    }),
+  ).resolves.toMatchObject({
+    version: 1,
+    notice: {
+      type: "auth_store_reset",
+      backupPath: join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json"),
+    },
+  });
+});
+
+test("backs up a wrong auth shape and resets the auth store", async () => {
+  const input = await createInput();
+  await writeRawStore(input, JSON.stringify({ version: 1, auth: { access: "a", refresh: "r", expires: "soon" } }));
+
+  await expect(
+    readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    }),
+  ).resolves.toMatchObject({
+    version: 1,
+    notice: {
+      type: "auth_store_reset",
+    },
+  });
+});
+
+test("backs up an invalid persisted notice shape and resets the auth store", async () => {
+  const input = await createInput();
+  await writeRawStore(input, JSON.stringify({ version: 1, notice: { type: "auth_store_reset" } }));
+
+  await expect(
+    readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    }),
+  ).resolves.toMatchObject({
+    version: 1,
+    notice: {
+      type: "auth_store_reset",
+    },
+  });
+});
+
+test("successful auth writes and explicit clears remove persisted notices", async () => {
+  const input = await createInput();
+  await writeSavedAuthNotice(input, {
+    type: "auth_store_reset",
+    message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+    backupPath: join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json"),
+  });
+
+  await writeSavedAuth(input, {
+    access: "access-token",
+    refresh: "saved-refresh",
+    expires: 12345,
+  });
+  await expect(readSavedAuth(input)).resolves.toEqual({
+    version: 1,
+    auth: {
+      access: "access-token",
+      refresh: "saved-refresh",
+      expires: 12345,
+    },
+  });
+
+  await writeSavedAuthNotice(input, {
+    type: "auth_store_reset",
+    message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+    backupPath: join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json"),
+  });
+  await clearSavedAuth(input);
+  await expect(readSavedAuth(input)).resolves.toEqual({ version: 1 });
+});
+```
+
+- [ ] **Step 2: Run store tests to verify failure**
+
+Run:
+
+```bash
+bun test test/server-store.test.ts
+```
+
+Expected: FAIL because `readSavedAuth` does not accept deps, `writeSavedAuthNotice` does not exist, and corrupt JSON still throws.
+
+- [ ] **Step 3: Implement store validation and recovery**
+
+Replace `src/server/store.ts` with this implementation, preserving existing exported aliases:
+
+```ts
+import { mkdir, rename } from "node:fs/promises";
+import { dirname, join, relative, resolve, sep } from "node:path";
+import type { PluginInput } from "@opencode-ai/plugin";
+
+import type { SupabaseLogger } from "../shared/log.ts";
+
+type StoreInput = Pick<PluginInput, "directory" | "worktree">;
+
+type StoreDeps = {
+  now?: () => Date;
+  logger?: Pick<SupabaseLogger, "warn">;
+};
+
+export type SavedAuth = {
+  access: string;
+  refresh: string;
+  expires: number;
+};
+
+export type SavedStateNotice = {
+  type: "auth_store_reset";
+  message: string;
+  backupPath: string;
+};
+
+export type SavedState = {
+  version: 1;
+  auth?: SavedAuth;
+  notice?: SavedStateNotice;
+};
+
+export const AUTH_STORE_RESET_MESSAGE =
+  "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.";
+
+const STORE_FILE = "supabase-auth.json";
+
+function resolveStoreRoot(input: StoreInput): string {
+  const directory = resolve(input.directory);
+  if (!input.worktree) {
+    return directory;
+  }
+
+  const worktree = resolve(input.worktree);
+  if (worktree === dirname(worktree)) {
+    return directory;
+  }
+
+  const pathFromWorktree = relative(worktree, directory);
+  if (
+    pathFromWorktree === "" ||
+    (!pathFromWorktree.startsWith("..") && !pathFromWorktree.startsWith(`..${sep}`))
+  ) {
+    return worktree;
+  }
+
+  return directory;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeAuth(value: unknown): SavedAuth {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Supabase auth store auth shape");
+  }
+  if (typeof value.access !== "string") {
+    throw new Error("Invalid Supabase auth store access token");
+  }
+  if (typeof value.refresh !== "string") {
+    throw new Error("Invalid Supabase auth store refresh value");
+  }
+  if (typeof value.expires !== "number" || !Number.isFinite(value.expires)) {
+    throw new Error("Invalid Supabase auth store expiry");
+  }
+
+  return {
+    access: value.access,
+    refresh: value.refresh,
+    expires: value.expires,
+  };
+}
+
+function normalizeNotice(value: unknown): SavedStateNotice {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Supabase auth store notice shape");
+  }
+  if (value.type !== "auth_store_reset") {
+    throw new Error("Unsupported Supabase auth store notice type");
+  }
+  if (typeof value.message !== "string" || typeof value.backupPath !== "string") {
+    throw new Error("Invalid Supabase auth store reset notice");
+  }
+
+  return {
+    type: "auth_store_reset",
+    message: value.message,
+    backupPath: value.backupPath,
+  };
+}
+
+function normalizeState(value: unknown): SavedState {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Supabase auth store shape");
+  }
+  if (value.version !== 1) {
+    throw new Error("Unsupported Supabase auth store version");
+  }
+
+  const state: SavedState = { version: 1 };
+  if (value.auth !== undefined) {
+    state.auth = normalizeAuth(value.auth);
+  }
+  if (value.notice !== undefined) {
+    state.notice = normalizeNotice(value.notice);
+  }
+  return state;
+}
+
+function formatBackupTimestamp(date: Date) {
+  return date.toISOString().replace(/[:.]/g, "-");
+}
+
+function backupFile(path: string, deps: StoreDeps) {
+  return join(dirname(path), `supabase-auth.corrupt-${formatBackupTimestamp(deps.now?.() ?? new Date())}.json`);
+}
+
+async function writeState(path: string, state: SavedState) {
+  await mkdir(dirname(path), { recursive: true });
+  await Bun.write(path, JSON.stringify(state, null, 2));
+}
+
+async function recoverCorruptStore(path: string, cause: unknown, deps: StoreDeps): Promise<SavedState> {
+  const backupPath = backupFile(path, deps);
+  await mkdir(dirname(path), { recursive: true });
+  await rename(path, backupPath);
+
+  const state: SavedState = {
+    version: 1,
+    notice: {
+      type: "auth_store_reset",
+      message: AUTH_STORE_RESET_MESSAGE,
+      backupPath,
+    },
+  };
+  await writeState(path, state);
+
+  await deps.logger?.warn("supabase auth store reset", {
+    reason: cause instanceof Error ? cause.message : String(cause),
+    path,
+    backupPath,
+  });
+
+  return state;
+}
+
+export function file(input: StoreInput): string {
+  const root = resolveStoreRoot(input);
+  return join(root, ".opencode", STORE_FILE);
+}
+
+export async function read(input: StoreInput, deps: StoreDeps = {}): Promise<SavedState> {
+  const path = file(input);
+  const authFile = Bun.file(path);
+  if (!(await authFile.exists())) {
+    return { version: 1 };
+  }
+
+  try {
+    return normalizeState(JSON.parse(await authFile.text()));
+  } catch (error) {
+    return recoverCorruptStore(path, error, deps);
+  }
+}
+
+export async function write(input: StoreInput, auth: SavedAuth): Promise<void> {
+  await writeState(file(input), { version: 1, auth });
+}
+
+export async function writeNotice(input: StoreInput, notice: SavedStateNotice): Promise<void> {
+  await writeState(file(input), { version: 1, notice });
+}
+
+export async function clear(input: StoreInput): Promise<void> {
+  await writeState(file(input), { version: 1 });
+}
+
+export const getStoreFile = file;
+export const readSavedAuth = read;
+export const writeSavedAuth = write;
+export const writeSavedAuthNotice = writeNotice;
+export const clearSavedAuth = clear;
+```
+
+- [ ] **Step 4: Run store tests to verify pass**
+
+Run:
+
+```bash
+bun test test/server-store.test.ts
+```
+
+Expected: PASS for all store tests.
+
+- [ ] **Step 5: Commit the store slice**
+
+```bash
+git add src/server/store.ts test/server-store.test.ts
+git commit -m "fix(auth): recover corrupt Supabase auth store"
+```
+
+## Task 2: Tool-Call Corruption Notices
+
+PR #51 is already merged on `main`. Preserve its refresh-race behavior while adding corrupt-store notices: keep in-flight refresh dedupe, keep `error.code === "unauthorized"` as the only broker refresh error that clears auth, keep ambiguous broker errors as `Supabase auth refresh failed: ...`, and only use corruption notice formatting when a store read recovers/reset state and returns no auth with `notice`.
+
+**Files:**
+- Modify: `src/server/tools.ts`
+- Test: `test/server-tools.test.ts`
+
+- [ ] **Step 1: Write failing tool test**
+
+Update the imports in `test/server-tools.test.ts`:
+
+```ts
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { dirname, join, resolve } from "node:path";
+```
+
+Add `getStoreFile` to the store import:
+
+```ts
+import { getStoreFile, readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
+```
+
+Add this helper after `createInput()`:
+
+```ts
+async function writeRawStore(input: TestPluginInput, contents: string) {
+  const path = getStoreFile(input);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents);
+  return path;
+}
+```
+
+Add this test inside `describe("server tools auth helper", () => { ... })` near the no-auth test:
+
+```ts
+test("tool auth reports corrupt store recovery with backup path", async () => {
+  const { input } = await createInput();
+  await writeRawStore(input, "{ not json");
+  const backupPath = join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json");
+
+  await expect(
+    ensureSupabaseToolAuth(
+      input,
+      {
+        clientId: "plugin-client",
+        oauthPort: 17670,
+      },
+      {
+        fetch: mock(async () => new Response("unexpected")),
+        now: () => new Date("2026-05-11T10:20:30.000Z"),
+      },
+    ),
+  ).rejects.toThrow(
+    `Supabase auth was reset because the local auth store was corrupted.\n\nThe corrupted file was preserved here:\n${backupPath}\n\nRun /supabase to reconnect, then retry this tool.`,
+  );
+
+  await expect(readSavedAuth(input)).resolves.toMatchObject({
+    version: 1,
+    notice: {
+      type: "auth_store_reset",
+      backupPath,
+    },
+  });
+});
+```
+
+- [ ] **Step 2: Run tool tests to verify failure**
+
+Run:
+
+```bash
+bun test test/server-tools.test.ts
+```
+
+Expected: FAIL because tool deps do not accept `now`, store notices are not formatted for tool errors, and corrupt JSON still throws.
+
+- [ ] **Step 3: Implement tool notice handling**
+
+Update the store import in `src/server/tools.ts`:
+
+```ts
+import {
+  type SavedAuth,
+  type SavedStateNotice,
+  clearSavedAuth,
+  getStoreFile,
+  readSavedAuth,
+  writeSavedAuth,
+} from "./store.ts";
+```
+
+Extend `ToolDeps`:
+
+```ts
+type ToolDeps = {
+  fetch?: FetchLike;
+  logger?: SupabaseLogger;
+  now?: () => Date;
+};
+```
+
+Add this helper near `NOT_CONNECTED_MESSAGE`:
+
+```ts
+function formatAuthNoticeForTool(notice: SavedStateNotice) {
+  return `${notice.message.replace(" Reconnect to continue.", ".")}\n\nThe corrupted file was preserved here:\n${notice.backupPath}\n\nRun /supabase to reconnect, then retry this tool.`;
+}
+```
+
+Update `SupabaseAuthStatus` disconnected variant:
+
+```ts
+  | {
+      status: "disconnected";
+      checked: boolean;
+      notice?: SavedStateNotice;
+    }
+```
+
+Update `getSupabaseAuthStatus(...)` to pass store deps and include notices:
+
+```ts
+export async function getSupabaseAuthStatus(
+  input: SupabaseToolInput,
+  options?: PluginOptions,
+  deps: ToolDeps = {},
+): Promise<SupabaseAuthStatus> {
+  const saved = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
+  if (!saved.auth) {
+    return saved.notice
+      ? { status: "disconnected", checked: false, notice: saved.notice }
+      : { status: "disconnected", checked: false };
+  }
+
+  if (!isRefreshNeeded(saved.auth)) {
+    return { status: "connected", auth: saved.auth, checked: false };
+  }
+
+  try {
+    const auth = await ensureSupabaseToolAuth(input, options, deps);
+    return { status: "connected", auth, checked: true };
+  } catch (error) {
+    const latest = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
+    if (!latest.auth && latest.notice) {
+      return { status: "disconnected", checked: true, notice: latest.notice };
+    }
+
+    const message = error instanceof Error ? error.message : String(error);
+    if (message === NOT_CONNECTED_MESSAGE) {
+      return { status: "disconnected", checked: true };
+    }
+
+    return { status: "unknown", checked: true, message };
+  }
+}
+```
+
+In `ensureSupabaseToolAuth(...)`, change the first no-auth block to:
+
+```ts
+const saved = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
+if (!saved.auth) {
+  throw new Error(saved.notice ? formatAuthNoticeForTool(saved.notice) : NOT_CONNECTED_MESSAGE);
+}
+```
+
+Change later `readSavedAuth(input)` calls in `ensureSupabaseToolAuth(...)` to pass the same deps:
+
+```ts
+const current = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
+const latest = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
+```
+
+Where a later no-auth branch throws `NOT_CONNECTED_MESSAGE`, preserve a corruption notice when present. This includes the `current` no-auth branch before broker refresh, the post-refresh `latest` no-auth branch, and the `BrokerClientError` catch branch when `latest.auth` is absent:
+
+```ts
+throw new Error(latest.notice ? formatAuthNoticeForTool(latest.notice) : NOT_CONNECTED_MESSAGE);
+```
+
+Do not change the PR #51 broker error branches except to pass store deps and format notices on no-auth states:
+
+```ts
+if (!isSameAuth(latest.auth, current.auth)) {
+  if (latest.auth) {
+    return latest.auth;
+  }
+  throw new Error(latest.notice ? formatAuthNoticeForTool(latest.notice) : NOT_CONNECTED_MESSAGE);
+}
+
+if (error.code === "unauthorized") {
+  await clearSavedAuth(input);
+  try {
+    await clearHostAuth(input, fetchImpl);
+  } catch {}
+  throw new Error(NOT_CONNECTED_MESSAGE);
+}
+
+throw new Error(`Supabase auth refresh failed: ${error.message}`);
+```
+
+- [ ] **Step 4: Run tool tests to verify pass**
+
+Run:
+
+```bash
+bun test test/server-tools.test.ts
+```
+
+Expected: PASS for tool auth tests.
+
+- [ ] **Step 5: Commit the tool slice**
+
+```bash
+git add src/server/tools.ts test/server-tools.test.ts
+git commit -m "fix(auth): surface corrupt store notices"
+```
+
+## Task 3: Server Auth Status Instructions Include Notices
+
+**Files:**
+- Modify: `src/server/auth.ts`
+- Test: `test/server-auth.test.ts`
+
+- [ ] **Step 1: Write failing server auth test**
+
+Add `writeSavedAuthNotice` to the store import in `test/server-auth.test.ts`:
+
+```ts
+import { readSavedAuth, writeSavedAuth, writeSavedAuthNotice } from "../src/server/store.ts";
+```
+
+Add this test after the existing disconnected status test:
+
+```ts
+test("status method reports disconnected notice when auth store was reset", async () => {
+  const input = await createInput();
+  const backupPath = join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json");
+  await writeSavedAuthNotice(input as never, {
+    type: "auth_store_reset",
+    message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+    backupPath,
+  });
+
+  const auth = createSupabaseAuth(input as never);
+  const result = await secondAuthMethod(auth).authorize();
+
+  expect(JSON.parse(result.instructions)).toEqual({
+    status: "disconnected",
+    checked: false,
+    notice: {
+      type: "auth_store_reset",
+      message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+      backupPath,
+    },
+  });
+});
+```
+
+- [ ] **Step 2: Run server auth tests to verify failure**
+
+Run:
+
+```bash
+bun test test/server-auth.test.ts
+```
+
+Expected: FAIL because status instructions do not include `notice`.
+
+- [ ] **Step 3: Implement notice-aware status instructions**
+
+Update imports in `src/server/auth.ts`:
+
+```ts
+import type { SavedStateNotice } from "./store.ts";
+import { readSavedAuth, writeSavedAuth } from "./store.ts";
+```
+
+Update the disconnected status type:
+
+```ts
+  | {
+      status: "disconnected";
+      checked: false;
+      notice?: SavedStateNotice;
+    }
+```
+
+Change `getStatusInstructions(...)` to accept deps and include notices:
+
+```ts
+async function getStatusInstructions(input: Pick<SupabaseAuthInput, "directory" | "worktree">, deps: AuthDeps = {}) {
+  const saved = await readSavedAuth(input, { logger: deps.logger });
+  if (!saved.auth) {
+    return encodeStatusInstructions(
+      saved.notice
+        ? { status: "disconnected", checked: false, notice: saved.notice }
+        : { status: "disconnected", checked: false },
+    );
+  }
+
+  if (!isRefreshNeeded(saved.auth.expires)) {
+    return encodeStatusInstructions({ status: "connected", checked: false });
+  }
+
+  return encodeStatusInstructions({ status: "refresh_required", checked: true });
+}
+```
+
+Update the status authorize call site:
+
+```ts
+const instructions = await getStatusInstructions(input, deps);
+```
+
+- [ ] **Step 4: Run server auth tests to verify pass**
+
+Run:
+
+```bash
+bun test test/server-auth.test.ts
+```
+
+Expected: PASS for server auth hook tests.
+
+- [ ] **Step 5: Commit the server auth slice**
+
+```bash
+git add src/server/auth.ts test/server-auth.test.ts
+git commit -m "fix(auth): include corrupt store notices in status"
+```
+
+## Task 4: TUI Persistent Corruption Dialog
+
+**Files:**
+- Modify: `src/tui/dialog.tsx`
+- Test: `test/plugin-exports.test.ts`
+
+- [ ] **Step 1: Write failing TUI tests**
+
+Add these tests near existing `runAuthPreflight` and dialog state tests in `test/plugin-exports.test.ts`:
+
+```ts
+test("supabase auth preflight surfaces corrupt-store notice", async () => {
+  const states: Array<Record<string, unknown>> = [];
+  const notice = {
+    type: "auth_store_reset",
+    message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+    backupPath: "/tmp/project/.opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+  };
+  const api = createDialogApi({
+    client: {
+      app: { log: (_input: unknown) => Promise.resolve(true) },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: { promptAsync: () => Promise.resolve({ data: true }) },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method?: number }) => {
+            if (method === 1) {
+              return Promise.resolve({
+                data: {
+                  url: "https://supabase.com/",
+                  instructions: JSON.stringify({ status: "disconnected", checked: false, notice }),
+                  method: "code",
+                },
+              });
+            }
+            return Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } });
+          },
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  });
+
+  await runAuthPreflight({
+    api: api as never,
+    logger: createLogger(),
+    setState: (state) => {
+      states.push(state as unknown as Record<string, unknown>);
+    },
+  });
+
+  expect(states).toEqual([{ type: "checking_auth" }, { type: "notice", notice }]);
+});
+
+test("supabase dialog notice shows backup path and reconnect action", async () => {
+  let authorizeCalls = 0;
+  const api = createDialogApi({
+    client: {
+      app: { log: (_input: unknown) => Promise.resolve(true) },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        create: () => Promise.resolve({ data: { id: "ses-notice" } }),
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method?: number }) => {
+            authorizeCalls += 1;
+            return Promise.resolve({
+              data: {
+                url: method === 1 ? "https://supabase.com/" : "https://example.com/auth",
+                instructions: method === 1 ? JSON.stringify({ status: "disconnected", checked: false }) : "Test",
+                method: "manual",
+              },
+            });
+          },
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  });
+
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: {
+      type: "notice",
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath: "/tmp/project/.opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+      },
+    },
+  }) as { title?: string; message?: string; onConfirm?: () => Promise<void> };
+
+  expect(dialog.title).toBe("Supabase auth reset");
+  expect(dialog.message).toContain("local auth store was corrupted");
+  expect(dialog.message).toContain("/tmp/project/.opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json");
+
+  await dialog.onConfirm?.();
+  expect(authorizeCalls).toBe(1);
+});
+```
+
+- [ ] **Step 2: Run TUI tests to verify failure**
+
+Run:
+
+```bash
+bun test test/plugin-exports.test.ts
+```
+
+Expected: FAIL because `AuthStatus` cannot parse notices and `OAuthState` has no `notice` state.
+
+- [ ] **Step 3: Implement notice parsing and dialog state**
+
+In `src/tui/dialog.tsx`, add notice type near `AuthStatus`:
+
+```ts
+type AuthNotice = {
+  type: "auth_store_reset";
+  message: string;
+  backupPath: string;
+};
+```
+
+Add notice state to `OAuthState`:
+
+```ts
+| { type: "notice"; notice: AuthNotice }
+```
+
+Update `AuthStatus` disconnected variant:
+
+```ts
+| { status: "disconnected"; checked: boolean; notice?: AuthNotice }
+```
+
+Add these helpers near `getErrorMessage(...)`:
+
+```ts
+function parseAuthNotice(value: unknown): AuthNotice | undefined {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return undefined;
+  }
+
+  const notice = value as Partial<AuthNotice>;
+  if (
+    notice.type === "auth_store_reset" &&
+    typeof notice.message === "string" &&
+    typeof notice.backupPath === "string"
+  ) {
+    return {
+      type: "auth_store_reset",
+      message: notice.message,
+      backupPath: notice.backupPath,
+    };
+  }
+
+  return undefined;
+}
+
+function noticeMessage(notice: AuthNotice) {
+  return `${notice.message}\n\nThe corrupted file was preserved here:\n${notice.backupPath}`;
+}
+```
+
+Update `parseAuthStatus(...)` so disconnected status may include a parsed notice:
+
+```ts
+function parseAuthStatus(instructions: string): AuthStatus {
+  const parsed = JSON.parse(instructions) as Partial<AuthStatus> & { notice?: unknown };
+  if (parsed.status === "connected") {
+    return { status: "connected", checked: Boolean(parsed.checked) };
+  }
+  if (parsed.status === "disconnected") {
+    const notice = parseAuthNotice(parsed.notice);
+    return notice
+      ? { status: "disconnected", checked: Boolean(parsed.checked), notice }
+      : { status: "disconnected", checked: Boolean(parsed.checked) };
+  }
+  if (parsed.status === "refresh_required") {
+    return { status: "refresh_required", checked: true };
+  }
+
+  throw new Error("Invalid Supabase auth status response");
+}
+```
+
+In `runAuthPreflight(...)`, change the disconnected branch:
+
+```ts
+if (status.status === "disconnected") {
+  context.setState(status.notice ? { type: "notice", notice: status.notice } : { type: "idle" });
+  return;
+}
+```
+
+Add a dialog branch before the existing `idle` branch:
+
+```tsx
+if (currentState.type === "notice") {
+  return props.api.ui.DialogConfirm({
+    title: "Supabase auth reset",
+    message: `${noticeMessage(currentState.notice)}\n\nReconnect to continue.`,
+    onConfirm: startOAuth,
+    onCancel: closeDialog,
+  });
+}
+```
+
+- [ ] **Step 4: Run TUI tests to verify pass**
+
+Run:
+
+```bash
+bun test test/plugin-exports.test.ts
+```
+
+Expected: PASS for existing and new TUI tests.
+
+- [ ] **Step 5: Commit the TUI slice**
+
+```bash
+git add src/tui/dialog.tsx test/plugin-exports.test.ts
+git commit -m "fix(tui): show corrupt auth store notice"
+```
+
+## Task 5: Final Verification
+
+**Files:**
+- Verify all modified code and tests
+
+- [ ] **Step 1: Run focused tests**
+
+Run:
+
+```bash
+bun test test/server-store.test.ts test/server-tools.test.ts test/server-auth.test.ts test/plugin-exports.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run lint**
+
+Run:
+
+```bash
+bun run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Inspect changed files**
+
+Run:
+
+```bash
+git status --short
+git diff -- src/server/store.ts src/server/tools.ts src/server/auth.ts src/tui/dialog.tsx test/server-store.test.ts test/server-tools.test.ts test/server-auth.test.ts test/plugin-exports.test.ts
+```
+
+Expected: only issue #34 implementation files are changed, with no unrelated edits.
+
+- [ ] **Step 5: Commit final verification notes if hooks or formatters changed files**
+
+If verification commands modify files, review the diff and commit those modifications:
+
+```bash
+git add src/server/store.ts src/server/tools.ts src/server/auth.ts src/tui/dialog.tsx test/server-store.test.ts test/server-tools.test.ts test/server-auth.test.ts test/plugin-exports.test.ts
+git commit -m "test(auth): cover corrupt store recovery"
+```
+
+Skip this commit when there are no new changes after the previous task commits.
+
+## Self-Review Checklist
+
+- Spec coverage: store corruption, backup, reset, persistent dialog, tool error, logging, and tests are covered.
+- Placeholder scan: plan contains concrete file paths, commands, expected outcomes, and code snippets.
+- Type consistency: `SavedStateNotice`, `AuthNotice`, and `auth_store_reset` names are consistent across store, tools, auth, TUI, and tests.
+- Scope check: issue #33 behavior, atomic writes, and remote credential revocation remain out of scope for issue #34.

--- a/docs/superpowers/specs/2026-05-11-corrupt-auth-store-design.md
+++ b/docs/superpowers/specs/2026-05-11-corrupt-auth-store-design.md
@@ -1,0 +1,188 @@
+# Corrupt Supabase Auth Store Recovery Design
+
+## Summary
+
+Issue #34 reports that `.opencode/supabase-auth.json` is trusted as valid JSON with the expected shape. If the file is truncated, manually edited, synced incorrectly, or has an unsupported version, the current `JSON.parse(...)` path throws and plugin auth paths can crash.
+
+The fix is to make auth-store reads fail closed: validate the file before trusting it, preserve any corrupt file as a timestamped backup, reset the canonical store to a valid empty state, persist a user-visible reset notice, and surface that notice through the `/supabase` dialog or direct tool-call errors.
+
+## Goals
+
+- Prevent corrupt local auth files from crashing server auth, `/supabase` preflight, or tool execution.
+- Preserve the corrupt file at `.opencode/supabase-auth.corrupt-<timestamp>.json` for user inspection.
+- Reset the canonical auth store to a valid version `1` state automatically.
+- Persist a durable corruption notice so `/supabase` shows a dialog instead of relying on a transient toast.
+- Make direct tool calls fail with a clear reconnect message when corruption is discovered there.
+- Log the original corruption error with enough context to diagnose it.
+- Add regression tests for invalid JSON, wrong store version, wrong top-level shape, wrong auth shape, tool-call discovery, and `/supabase` notice rendering.
+
+## Non-Goals
+
+- Do not change issue #33 behavior in this issue. PR #51 covers that work.
+- Do not revoke Supabase credentials remotely.
+- Do not add a new user command.
+- Do not change the OAuth broker contract.
+- Do not introduce a schema validation dependency for this small persisted shape.
+- Do not make every store write atomic in this issue. Atomic writes are useful future hardening but are separate from recovering existing corrupt stores.
+
+## Existing Behavior
+
+`src/server/store.ts` currently reads the auth store with:
+
+```ts
+const parsed = JSON.parse(await authFile.text()) as SavedState;
+```
+
+It then checks only `parsed.version !== 1` and returns auth if present. Invalid JSON, non-object values, wrong `auth` shape, and unsupported versions can throw through callers.
+
+Call paths that read saved auth include:
+
+- `/supabase` preflight through `src/server/auth.ts`
+- tool auth through `ensureSupabaseToolAuth(...)` in `src/server/tools.ts`
+- auth status checks through `getSupabaseAuthStatus(...)`
+
+## Persisted State
+
+Extend the store state with a corruption notice field that is valid persisted state, not transient process memory.
+
+```ts
+export type SavedStateNotice = {
+  type: "auth_store_reset";
+  message: string;
+  backupPath: string;
+};
+
+export type SavedState = {
+  version: 1;
+  auth?: SavedAuth;
+  notice?: SavedStateNotice;
+};
+```
+
+The canonical store after corruption recovery should look like this:
+
+```json
+{
+  "version": 1,
+  "notice": {
+    "type": "auth_store_reset",
+    "message": "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+    "backupPath": ".opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json"
+  }
+}
+```
+
+`writeSavedAuth(...)` clears the notice by writing `{ version: 1, auth }` after successful reconnect. `clearSavedAuth(...)` clears the notice by writing `{ version: 1 }` after explicit disconnect.
+
+## Store Validation
+
+`readSavedAuth(input, deps?)` should own the validation and recovery policy because it owns the persisted file format.
+
+Validation rules:
+
+- Missing file returns `{ version: 1 }`.
+- Top-level value must be a non-array object.
+- `version` must be exactly `1`.
+- `auth`, when present, must be a non-array object with `access: string`, `refresh: string`, and `expires: finite number`.
+- `notice`, when present, must be an `auth_store_reset` object with string `message` and `backupPath` fields.
+
+If parsing or validation fails, `readSavedAuth(...)` should:
+
+1. Compute a deterministic backup path using a timestamp, for example `.opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json`.
+2. Move the bad canonical store to that path.
+3. Write the canonical store as valid empty state with an `auth_store_reset` notice.
+4. Log a warning with the original error message, canonical path, and backup path.
+5. Return the reset state, including the notice.
+
+Tests should inject the timestamp to make backup names deterministic.
+
+## User Experience
+
+### `/supabase` Dialog Path
+
+When `/supabase` preflight sees a disconnected state with an `auth_store_reset` notice, it should render a persistent confirm dialog.
+
+- Title: `Supabase auth reset`
+- Message says the local auth file was corrupted and Supabase auth was reset.
+- Message includes the exact backup path.
+- Confirm starts OAuth reconnect.
+- Cancel closes the dialog.
+
+The notice remains persisted when the user cancels. Running `/supabase` again should show the same dialog until successful reconnect or explicit disconnect clears the notice.
+
+### Direct Tool Path
+
+Tool execution cannot reliably open a TUI dialog. If `ensureSupabaseToolAuth(...)` discovers corruption, the tool should throw a clear error and leave the notice in the store for the next `/supabase` run.
+
+Tool error:
+
+```text
+Supabase auth was reset because the local auth store was corrupted.
+
+The corrupted file was preserved here:
+.opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json
+
+Run /supabase to reconnect, then retry this tool.
+```
+
+## Server API Changes
+
+`src/server/store.ts` should export `SavedStateNotice` and a helper for writing a notice-only state, for example `writeSavedAuthNotice(input, notice)`. This helper is only for persisted auth-store corruption notices.
+
+`src/server/tools.ts` should:
+
+- pass logger deps into `readSavedAuth(...)` so corruption recovery can be logged from tool paths
+- format `auth_store_reset` notices into direct tool errors
+- include `notice` on disconnected auth-status results
+
+`src/server/auth.ts` should include optional `notice` data in status instructions so the TUI can render the reset dialog.
+
+## TUI Changes
+
+`src/tui/dialog.tsx` should parse optional `auth_store_reset` notice data from status instructions.
+
+Add a state like:
+
+```ts
+| { type: "notice"; notice: AuthNotice }
+```
+
+When preflight reads `{ status: "disconnected", notice }`, set the notice state instead of the generic idle state.
+
+## Logging
+
+Store corruption recovery should log:
+
+- event: `supabase auth store reset`
+- original error message
+- canonical store path
+- backup path
+
+Do not log auth secrets, OAuth codes, or full auth file contents.
+
+## Testing Expectations
+
+Add automated coverage for these cases:
+
+- invalid JSON is backed up, canonical store is reset, and `auth_store_reset` notice is returned
+- unsupported version is backed up, canonical store is reset, and `auth_store_reset` notice is returned
+- wrong top-level shape is backed up, canonical store is reset, and `auth_store_reset` notice is returned
+- wrong `auth` shape is treated as corruption
+- invalid persisted notice shape is treated as corruption
+- backup file keeps the original corrupt bytes
+- successful `writeSavedAuth(...)` clears a prior notice
+- explicit `clearSavedAuth(...)` clears a prior notice
+- direct tool call with a corrupt store throws a reconnect message with backup path
+- auth status instructions include notice when disconnected because of recovery
+- `/supabase` preflight maps the notice to a persistent dialog
+- `/supabase` confirm from a notice dialog starts OAuth reconnect
+
+## Acceptance Criteria
+
+- Invalid JSON and unsupported structure/version do not crash the plugin.
+- Corrupted file is preserved under deterministic backup name in tests.
+- Canonical auth store is recreated as valid version `1` state with an `auth_store_reset` notice.
+- User sees clear reconnect instructions in a persistent `/supabase` dialog.
+- Dialog message includes that the auth file was corrupted and where it was backed up.
+- Tool-call failure tells the user where the corrupt file was backed up, then tells them to run `/supabase` and retry.
+- Existing connected, disconnected, unknown, and disconnect behavior remains intact.

--- a/src/server/auth.ts
+++ b/src/server/auth.ts
@@ -12,6 +12,7 @@ import type { SupabaseLogger } from "../shared/log.ts";
 import { buildAuthorizeUrl, generatePKCE, generateState } from "../shared/oauth.ts";
 import type { FetchLike, SupabaseTokenResponse } from "../shared/types.ts";
 import { HTML_SUCCESS, htmlError } from "./auth-html.ts";
+import type { SavedStateNotice } from "./store.ts";
 import { readSavedAuth, writeSavedAuth } from "./store.ts";
 import { NOT_CONNECTED_MESSAGE, disconnectSupabaseAuth, ensureSupabaseToolAuth } from "./tools.ts";
 
@@ -44,6 +45,7 @@ type SupabaseStatusInstructions =
   | {
       status: "disconnected";
       checked: false;
+      notice?: SavedStateNotice;
     }
   | {
       status: "refresh_required";
@@ -63,10 +65,14 @@ function encodeStatusInstructions(status: SupabaseStatusInstructions) {
   return JSON.stringify(status);
 }
 
-async function getStatusInstructions(input: Pick<SupabaseAuthInput, "directory" | "worktree">) {
-  const saved = await readSavedAuth(input);
+async function getStatusInstructions(input: Pick<SupabaseAuthInput, "directory" | "worktree">, deps: AuthDeps = {}) {
+  const saved = await readSavedAuth(input, { logger: deps.logger });
   if (!saved.auth) {
-    return encodeStatusInstructions({ status: "disconnected", checked: false });
+    return encodeStatusInstructions(
+      saved.notice
+        ? { status: "disconnected", checked: false, notice: saved.notice }
+        : { status: "disconnected", checked: false },
+    );
   }
 
   if (!isRefreshNeeded(saved.auth.expires)) {
@@ -360,7 +366,7 @@ export function createSupabaseAuth(
             };
           }
 
-          const instructions = await getStatusInstructions(input);
+          const instructions = await getStatusInstructions(input, deps);
           const status = JSON.parse(instructions) as SupabaseStatusInstructions;
 
           if (status.status !== "refresh_required") {

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { mkdir, open, rename, unlink } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import type { PluginInput } from "@opencode-ai/plugin";
@@ -34,7 +35,33 @@ const AUTH_STORE_RESET_MESSAGE = "Supabase auth was reset because the local auth
 const RECOVERY_LOCK_SUFFIX = ".recovering.lock";
 const RECOVERY_MAX_WAIT_MS = 5000;
 const RECOVERY_POLL_MS = 50;
+const RECOVERY_LOCK_STALE_MS = 10_000;
 const inFlightRecoveries = new Map<string, Promise<SavedState>>();
+
+type RecoveryLockMetadata = {
+  startedAt?: number;
+  token?: string;
+};
+
+type RecoveryLock = {
+  fd: import("node:fs/promises").FileHandle;
+  token: string;
+};
+
+async function readLockMetadata(lockPath: string): Promise<RecoveryLockMetadata> {
+  try {
+    const text = await Bun.file(lockPath).text();
+    return JSON.parse(text) as { startedAt?: number };
+  } catch {
+    return {};
+  }
+}
+
+async function isStaleLock(lockPath: string): Promise<boolean> {
+  const metadata = await readLockMetadata(lockPath);
+  if (!metadata.startedAt) return true;
+  return Date.now() - metadata.startedAt > RECOVERY_LOCK_STALE_MS;
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -124,24 +151,47 @@ async function writeState(path: string, state: SavedState): Promise<void> {
   await Bun.write(path, JSON.stringify(state, null, 2));
 }
 
-async function acquireRecoveryLock(lockPath: string): Promise<import("node:fs/promises").FileHandle | undefined> {
-  try {
-    const fd = await open(lockPath, "wx");
-    return fd;
-  } catch (error) {
-    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
-      return undefined;
+async function acquireRecoveryLock(lockPath: string): Promise<RecoveryLock | undefined> {
+  async function tryCreate(): Promise<RecoveryLock | undefined> {
+    try {
+      const fd = await open(lockPath, "wx");
+      const token = randomUUID();
+      const metadata = JSON.stringify({ startedAt: Date.now(), token });
+      await fd.write(metadata, 0, "utf8");
+      return { fd, token };
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+        return undefined;
+      }
+      throw error;
     }
-    throw error;
   }
+
+  const lock = await tryCreate();
+  if (lock) return lock;
+
+  // Lock exists; check if stale and take over if so.
+  if (await isStaleLock(lockPath)) {
+    try {
+      await unlink(lockPath);
+    } catch {
+      // Another process may have already removed it.
+    }
+    return tryCreate();
+  }
+
+  return undefined;
 }
 
-async function releaseRecoveryLock(fd: import("node:fs/promises").FileHandle, lockPath: string): Promise<void> {
+async function releaseRecoveryLock(lock: RecoveryLock, lockPath: string): Promise<void> {
   try {
-    await fd.close();
+    await lock.fd.close();
   } catch {}
   try {
-    await unlink(lockPath);
+    const metadata = await readLockMetadata(lockPath);
+    if (metadata.token === lock.token) {
+      await unlink(lockPath);
+    }
   } catch {}
 }
 
@@ -191,7 +241,16 @@ async function recoverCorruptStoreOnce(path: string, error: unknown, deps: Store
       };
 
       await mkdir(dirname(path), { recursive: true });
-      await rename(path, backupPath);
+      try {
+        await rename(path, backupPath);
+      } catch (renameError) {
+        if ((renameError as NodeJS.ErrnoException).code === "ENOENT") {
+          // Store disappeared before we could back it up; write clean state directly.
+          await writeState(path, { version: 1 });
+          return { version: 1 } as SavedState;
+        }
+        throw renameError;
+      }
       await writeState(path, state);
       await deps.logger?.warn("supabase auth store reset", {
         reason: error instanceof Error ? error.message : String(error),
@@ -202,9 +261,10 @@ async function recoverCorruptStoreOnce(path: string, error: unknown, deps: Store
       return state;
     } finally {
       await releaseRecoveryLock(lock, lockPath);
-      inFlightRecoveries.delete(path);
     }
-  })();
+  })().finally(() => {
+    inFlightRecoveries.delete(path);
+  });
 
   inFlightRecoveries.set(path, recovery);
   return recovery;

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -1,4 +1,4 @@
-import { mkdir, rename } from "node:fs/promises";
+import { mkdir, open, rename, unlink } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import type { PluginInput } from "@opencode-ai/plugin";
 
@@ -31,6 +31,9 @@ export type SavedState = {
 
 const STORE_FILE = "supabase-auth.json";
 const AUTH_STORE_RESET_MESSAGE = "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.";
+const RECOVERY_LOCK_SUFFIX = ".recovering.lock";
+const RECOVERY_MAX_WAIT_MS = 5000;
+const RECOVERY_POLL_MS = 50;
 const inFlightRecoveries = new Map<string, Promise<SavedState>>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -105,9 +108,15 @@ function normalizeState(value: unknown): SavedState {
   };
 }
 
-function backupFile(path: string, now: () => Date) {
+async function backupFile(path: string, now: () => Date) {
   const timestamp = now().toISOString().replace(/[:.]/g, "-");
-  return join(dirname(path), `supabase-auth.corrupt-${timestamp}.json`);
+  let candidate = join(dirname(path), `supabase-auth.corrupt-${timestamp}.json`);
+  let counter = 1;
+  while (await Bun.file(candidate).exists()) {
+    candidate = join(dirname(path), `supabase-auth.corrupt-${timestamp}-${counter}.json`);
+    counter++;
+  }
+  return candidate;
 }
 
 async function writeState(path: string, state: SavedState): Promise<void> {
@@ -115,13 +124,63 @@ async function writeState(path: string, state: SavedState): Promise<void> {
   await Bun.write(path, JSON.stringify(state, null, 2));
 }
 
+async function acquireRecoveryLock(lockPath: string): Promise<import("node:fs/promises").FileHandle | undefined> {
+  try {
+    const fd = await open(lockPath, "wx");
+    return fd;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "EEXIST") {
+      return undefined;
+    }
+    throw error;
+  }
+}
+
+async function releaseRecoveryLock(fd: import("node:fs/promises").FileHandle, lockPath: string): Promise<void> {
+  try {
+    await fd.close();
+  } catch {}
+  try {
+    await unlink(lockPath);
+  } catch {}
+}
+
+async function waitForRecoveredState(path: string, deps: StoreDeps): Promise<SavedState> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < RECOVERY_MAX_WAIT_MS) {
+    try {
+      const text = await Bun.file(path).text();
+      return normalizeState(JSON.parse(text));
+    } catch {
+      // not ready yet
+    }
+    await new Promise((resolve) => setTimeout(resolve, RECOVERY_POLL_MS));
+  }
+  throw new Error("Supabase auth store recovery timed out waiting for another process");
+}
+
 async function recoverCorruptStoreOnce(path: string, error: unknown, deps: StoreDeps): Promise<SavedState> {
   const existing = inFlightRecoveries.get(path);
   if (existing) return existing;
 
   const recovery = (async () => {
+    const lockPath = path + RECOVERY_LOCK_SUFFIX;
+    const lock = await acquireRecoveryLock(lockPath);
+    if (!lock) {
+      return waitForRecoveredState(path, deps);
+    }
+
     try {
-      const backupPath = backupFile(path, deps.now ?? (() => new Date()));
+      // Re-read under lock in case another process already fixed it.
+      try {
+        const text = await Bun.file(path).text();
+        const state = normalizeState(JSON.parse(text));
+        return state;
+      } catch {
+        // still corrupt or missing
+      }
+
+      const backupPath = await backupFile(path, deps.now ?? (() => new Date()));
       const state: SavedState = {
         version: 1,
         notice: {
@@ -142,6 +201,7 @@ async function recoverCorruptStoreOnce(path: string, error: unknown, deps: Store
 
       return state;
     } finally {
+      await releaseRecoveryLock(lock, lockPath);
       inFlightRecoveries.delete(path);
     }
   })();

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -1,8 +1,15 @@
-import { mkdir } from "node:fs/promises";
+import { mkdir, rename } from "node:fs/promises";
 import { dirname, join, relative, resolve, sep } from "node:path";
 import type { PluginInput } from "@opencode-ai/plugin";
 
+import type { SupabaseLogger } from "../shared/log.ts";
+
 type StoreInput = Pick<PluginInput, "directory" | "worktree">;
+
+type StoreDeps = {
+  now?: () => Date;
+  logger?: Pick<SupabaseLogger, "warn">;
+};
 
 export type SavedAuth = {
   access: string;
@@ -10,12 +17,125 @@ export type SavedAuth = {
   expires: number;
 };
 
+export type SavedStateNotice = {
+  type: "auth_store_reset";
+  message: string;
+  backupPath: string;
+};
+
 export type SavedState = {
   version: 1;
   auth?: SavedAuth;
+  notice?: SavedStateNotice;
 };
 
 const STORE_FILE = "supabase-auth.json";
+const AUTH_STORE_RESET_MESSAGE = "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizeAuth(value: unknown): SavedAuth | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw new Error("Invalid Supabase auth store auth shape");
+  }
+
+  if (
+    typeof value.access !== "string" ||
+    typeof value.refresh !== "string" ||
+    typeof value.expires !== "number" ||
+    !Number.isFinite(value.expires)
+  ) {
+    throw new Error("Invalid Supabase auth store auth shape");
+  }
+
+  return {
+    access: value.access,
+    refresh: value.refresh,
+    expires: value.expires,
+  };
+}
+
+function normalizeNotice(value: unknown): SavedStateNotice | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!isRecord(value)) {
+    throw new Error("Invalid Supabase auth store notice shape");
+  }
+
+  if (
+    value.type !== "auth_store_reset" ||
+    typeof value.message !== "string" ||
+    typeof value.backupPath !== "string"
+  ) {
+    throw new Error("Invalid Supabase auth store notice shape");
+  }
+
+  return {
+    type: "auth_store_reset",
+    message: value.message,
+    backupPath: value.backupPath,
+  };
+}
+
+function normalizeState(value: unknown): SavedState {
+  if (!isRecord(value)) {
+    throw new Error("Invalid Supabase auth store shape");
+  }
+
+  if (value.version !== 1) {
+    throw new Error("Unsupported Supabase auth store version");
+  }
+
+  const auth = normalizeAuth(value.auth);
+  const notice = normalizeNotice(value.notice);
+
+  return {
+    version: 1,
+    ...(auth ? { auth } : {}),
+    ...(notice ? { notice } : {}),
+  };
+}
+
+function backupFile(path: string, now: () => Date) {
+  const timestamp = now().toISOString().replace(/[:.]/g, "-");
+  return join(dirname(path), `supabase-auth.corrupt-${timestamp}.json`);
+}
+
+async function writeState(path: string, state: SavedState): Promise<void> {
+  await mkdir(dirname(path), { recursive: true });
+  await Bun.write(path, JSON.stringify(state, null, 2));
+}
+
+async function recoverCorruptStore(path: string, error: unknown, deps: StoreDeps): Promise<SavedState> {
+  const backupPath = backupFile(path, deps.now ?? (() => new Date()));
+  const state: SavedState = {
+    version: 1,
+    notice: {
+      type: "auth_store_reset",
+      message: AUTH_STORE_RESET_MESSAGE,
+      backupPath,
+    },
+  };
+
+  await mkdir(dirname(path), { recursive: true });
+  await rename(path, backupPath);
+  await writeState(path, state);
+  await deps.logger?.warn("supabase auth store reset", {
+    reason: error instanceof Error ? error.message : String(error),
+    path,
+    backupPath,
+  });
+
+  return state;
+}
 
 // Use worktree only when it is non-root and directory is equal to or inside it;
 // otherwise fall back to the session directory.
@@ -46,32 +166,34 @@ export function file(input: StoreInput): string {
   return join(root, ".opencode", STORE_FILE);
 }
 
-export async function read(input: StoreInput): Promise<SavedState> {
-  const authFile = Bun.file(file(input));
+export async function read(input: StoreInput, deps: StoreDeps = {}): Promise<SavedState> {
+  const path = file(input);
+  const authFile = Bun.file(path);
   if (!(await authFile.exists())) {
     return { version: 1 };
   }
 
-  const parsed = JSON.parse(await authFile.text()) as SavedState;
-  if (parsed.version !== 1) {
-    throw new Error("Unsupported Supabase auth store version");
+  try {
+    return normalizeState(JSON.parse(await authFile.text()));
+  } catch (error) {
+    return recoverCorruptStore(path, error, deps);
   }
-  return parsed.auth ? { version: 1, auth: parsed.auth } : { version: 1 };
 }
 
 export async function write(input: StoreInput, auth: SavedAuth): Promise<void> {
-  const path = file(input);
-  await mkdir(dirname(path), { recursive: true });
-  await Bun.write(path, JSON.stringify({ version: 1, auth }, null, 2));
+  await writeState(file(input), { version: 1, auth });
+}
+
+export async function writeNotice(input: StoreInput, notice: SavedStateNotice): Promise<void> {
+  await writeState(file(input), { version: 1, notice });
 }
 
 export async function clear(input: StoreInput): Promise<void> {
-  const path = file(input);
-  await mkdir(dirname(path), { recursive: true });
-  await Bun.write(path, JSON.stringify({ version: 1 }, null, 2));
+  await writeState(file(input), { version: 1 });
 }
 
 export const getStoreFile = file;
 export const readSavedAuth = read;
 export const writeSavedAuth = write;
+export const writeSavedAuthNotice = writeNotice;
 export const clearSavedAuth = clear;

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -31,6 +31,7 @@ export type SavedState = {
 
 const STORE_FILE = "supabase-auth.json";
 const AUTH_STORE_RESET_MESSAGE = "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.";
+const inFlightRecoveries = new Map<string, Promise<SavedState>>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -114,27 +115,39 @@ async function writeState(path: string, state: SavedState): Promise<void> {
   await Bun.write(path, JSON.stringify(state, null, 2));
 }
 
-async function recoverCorruptStore(path: string, error: unknown, deps: StoreDeps): Promise<SavedState> {
-  const backupPath = backupFile(path, deps.now ?? (() => new Date()));
-  const state: SavedState = {
-    version: 1,
-    notice: {
-      type: "auth_store_reset",
-      message: AUTH_STORE_RESET_MESSAGE,
-      backupPath,
-    },
-  };
+async function recoverCorruptStoreOnce(path: string, error: unknown, deps: StoreDeps): Promise<SavedState> {
+  const existing = inFlightRecoveries.get(path);
+  if (existing) return existing;
 
-  await mkdir(dirname(path), { recursive: true });
-  await rename(path, backupPath);
-  await writeState(path, state);
-  await deps.logger?.warn("supabase auth store reset", {
-    reason: error instanceof Error ? error.message : String(error),
-    path,
-    backupPath,
-  });
+  const recovery = (async () => {
+    try {
+      const backupPath = backupFile(path, deps.now ?? (() => new Date()));
+      const state: SavedState = {
+        version: 1,
+        notice: {
+          type: "auth_store_reset",
+          message: AUTH_STORE_RESET_MESSAGE,
+          backupPath,
+        },
+      };
 
-  return state;
+      await mkdir(dirname(path), { recursive: true });
+      await rename(path, backupPath);
+      await writeState(path, state);
+      await deps.logger?.warn("supabase auth store reset", {
+        reason: error instanceof Error ? error.message : String(error),
+        path,
+        backupPath,
+      });
+
+      return state;
+    } finally {
+      inFlightRecoveries.delete(path);
+    }
+  })();
+
+  inFlightRecoveries.set(path, recovery);
+  return recovery;
 }
 
 // Use worktree only when it is non-root and directory is equal to or inside it;
@@ -176,7 +189,7 @@ export async function read(input: StoreInput, deps: StoreDeps = {}): Promise<Sav
   try {
     return normalizeState(JSON.parse(await authFile.text()));
   } catch (error) {
-    return recoverCorruptStore(path, error, deps);
+    return recoverCorruptStoreOnce(path, error, deps);
   }
 }
 

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -303,6 +303,10 @@ export async function read(input: StoreInput, deps: StoreDeps = {}): Promise<Sav
   const path = file(input);
   const authFile = Bun.file(path);
   if (!(await authFile.exists())) {
+    const lockPath = path + RECOVERY_LOCK_SUFFIX;
+    if ((await Bun.file(lockPath).exists()) && !(await isStaleLock(lockPath))) {
+      return waitForRecoveredState(path, deps);
+    }
     return { version: 1 };
   }
 

--- a/src/server/store.ts
+++ b/src/server/store.ts
@@ -59,7 +59,7 @@ async function readLockMetadata(lockPath: string): Promise<RecoveryLockMetadata>
 
 async function isStaleLock(lockPath: string): Promise<boolean> {
   const metadata = await readLockMetadata(lockPath);
-  if (!metadata.startedAt) return true;
+  if (typeof metadata.startedAt !== "number" || !Number.isFinite(metadata.startedAt)) return true;
   return Date.now() - metadata.startedAt > RECOVERY_LOCK_STALE_MS;
 }
 

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -312,6 +312,13 @@ export async function ensureSupabaseToolAuth(
         try {
           await clearHostAuth(input, fetchImpl);
         } catch {}
+      } else {
+        const latest = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
+        if (!latest.auth && latest.notice) {
+          try {
+            await clearHostAuth(input, fetchImpl);
+          } catch {}
+        }
       }
       throw error;
     }

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -10,11 +10,19 @@ import {
 import { readSupabaseConfig } from "../shared/cfg.ts";
 import type { SupabaseLogger } from "../shared/log.ts";
 import type { FetchLike } from "../shared/types.ts";
-import { type SavedAuth, clearSavedAuth, getStoreFile, readSavedAuth, writeSavedAuth } from "./store.ts";
+import {
+  type SavedAuth,
+  type SavedStateNotice,
+  clearSavedAuth,
+  getStoreFile,
+  readSavedAuth,
+  writeSavedAuth,
+} from "./store.ts";
 
 type ToolDeps = {
   fetch?: FetchLike;
   logger?: SupabaseLogger;
+  now?: () => Date;
 };
 
 type InFlightRefresh = {
@@ -59,6 +67,7 @@ export type SupabaseAuthStatus =
   | {
       status: "disconnected";
       checked: boolean;
+      notice?: SavedStateNotice;
     }
   | {
       status: "unknown";
@@ -69,6 +78,10 @@ export type SupabaseAuthStatus =
 export const NOT_CONNECTED_MESSAGE = "Supabase is not connected. Run /supabase first.";
 const REFRESH_BUFFER_MS = 30_000;
 const inFlightRefreshes = new Map<string, InFlightRefresh>();
+
+function formatAuthNoticeForTool(notice: SavedStateNotice) {
+  return `${notice.message.replace(". Reconnect to continue.", ".")}\n\nThe corrupted file was preserved here:\n${notice.backupPath}\n\nRun /supabase to reconnect, then retry this tool.`;
+}
 
 function isRefreshNeeded(auth: SavedAuth) {
   return auth.expires <= Date.now() + REFRESH_BUFFER_MS;
@@ -236,9 +249,11 @@ export async function getSupabaseAuthStatus(
   options?: PluginOptions,
   deps: ToolDeps = {},
 ): Promise<SupabaseAuthStatus> {
-  const saved = await readSavedAuth(input);
+  const saved = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
   if (!saved.auth) {
-    return { status: "disconnected", checked: false };
+    return saved.notice
+      ? { status: "disconnected", checked: false, notice: saved.notice }
+      : { status: "disconnected", checked: false };
   }
 
   if (!isRefreshNeeded(saved.auth)) {
@@ -249,6 +264,11 @@ export async function getSupabaseAuthStatus(
     const auth = await ensureSupabaseToolAuth(input, options, deps);
     return { status: "connected", auth, checked: true };
   } catch (error) {
+    const latest = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
+    if (!latest.auth && latest.notice) {
+      return { status: "disconnected", checked: true, notice: latest.notice };
+    }
+
     const message = error instanceof Error ? error.message : String(error);
     if (message === NOT_CONNECTED_MESSAGE) {
       return { status: "disconnected", checked: true };
@@ -264,9 +284,9 @@ export async function ensureSupabaseToolAuth(
   deps: ToolDeps = {},
 ): Promise<SavedAuth> {
   const refreshKey = getStoreFile(input);
-  const saved = await readSavedAuth(input);
+  const saved = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
   if (!saved.auth) {
-    throw new Error(NOT_CONNECTED_MESSAGE);
+    throw new Error(saved.notice ? formatAuthNoticeForTool(saved.notice) : NOT_CONNECTED_MESSAGE);
   }
 
   const inFlight = inFlightRefreshes.get(refreshKey);
@@ -300,9 +320,9 @@ export async function ensureSupabaseToolAuth(
   };
   const refreshPromise = (async () => {
     const fetchImpl = deps.fetch ?? fetch;
-    const current = await readSavedAuth(input);
+    const current = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
     if (!current.auth) {
-      throw new Error(NOT_CONNECTED_MESSAGE);
+      throw new Error(current.notice ? formatAuthNoticeForTool(current.notice) : NOT_CONNECTED_MESSAGE);
     }
 
     if (!isRefreshNeeded(current.auth)) {
@@ -325,9 +345,9 @@ export async function ensureSupabaseToolAuth(
         expires: Date.now() + (refreshed.expires_in ?? 3600) * 1000,
       };
 
-      const latest = await readSavedAuth(input);
+      const latest = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
       if (!latest.auth) {
-        throw new Error(NOT_CONNECTED_MESSAGE);
+        throw new Error(latest.notice ? formatAuthNoticeForTool(latest.notice) : NOT_CONNECTED_MESSAGE);
       }
 
       if (!isSameAuth(latest.auth, current.auth)) {
@@ -338,12 +358,12 @@ export async function ensureSupabaseToolAuth(
       return nextAuth;
     } catch (error) {
       if (error instanceof BrokerClientError) {
-        const latest = await readSavedAuth(input);
+        const latest = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
         if (!isSameAuth(latest.auth, current.auth)) {
           if (latest.auth) {
             return latest.auth;
           }
-          throw new Error(NOT_CONNECTED_MESSAGE);
+          throw new Error(latest.notice ? formatAuthNoticeForTool(latest.notice) : NOT_CONNECTED_MESSAGE);
         }
 
         if (error.code === "unauthorized") {

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -83,6 +83,14 @@ function formatAuthNoticeForTool(notice: SavedStateNotice) {
   return `${notice.message.replace(". Reconnect to continue.", ".")}\n\nThe corrupted file was preserved here:\n${notice.backupPath}\n\nRun /supabase to reconnect, then retry this tool.`;
 }
 
+async function throwAuthNotice(input: SupabaseToolInput, notice: SavedStateNotice, deps: ToolDeps): Promise<never> {
+  const fetchImpl = deps.fetch ?? fetch;
+  try {
+    await clearHostAuth(input, fetchImpl);
+  } catch {}
+  throw new Error(formatAuthNoticeForTool(notice));
+}
+
 function isRefreshNeeded(auth: SavedAuth) {
   return auth.expires <= Date.now() + REFRESH_BUFFER_MS;
 }
@@ -286,7 +294,10 @@ export async function ensureSupabaseToolAuth(
   const refreshKey = getStoreFile(input);
   const saved = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
   if (!saved.auth) {
-    throw new Error(saved.notice ? formatAuthNoticeForTool(saved.notice) : NOT_CONNECTED_MESSAGE);
+    if (saved.notice) {
+      await throwAuthNotice(input, saved.notice, deps);
+    }
+    throw new Error(NOT_CONNECTED_MESSAGE);
   }
 
   const inFlight = inFlightRefreshes.get(refreshKey);
@@ -322,7 +333,10 @@ export async function ensureSupabaseToolAuth(
     const fetchImpl = deps.fetch ?? fetch;
     const current = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
     if (!current.auth) {
-      throw new Error(current.notice ? formatAuthNoticeForTool(current.notice) : NOT_CONNECTED_MESSAGE);
+      if (current.notice) {
+        await throwAuthNotice(input, current.notice, deps);
+      }
+      throw new Error(NOT_CONNECTED_MESSAGE);
     }
 
     if (!isRefreshNeeded(current.auth)) {
@@ -347,7 +361,10 @@ export async function ensureSupabaseToolAuth(
 
       const latest = await readSavedAuth(input, { logger: deps.logger, now: deps.now });
       if (!latest.auth) {
-        throw new Error(latest.notice ? formatAuthNoticeForTool(latest.notice) : NOT_CONNECTED_MESSAGE);
+        if (latest.notice) {
+          await throwAuthNotice(input, latest.notice, deps);
+        }
+        throw new Error(NOT_CONNECTED_MESSAGE);
       }
 
       if (!isSameAuth(latest.auth, current.auth)) {
@@ -363,7 +380,10 @@ export async function ensureSupabaseToolAuth(
           if (latest.auth) {
             return latest.auth;
           }
-          throw new Error(latest.notice ? formatAuthNoticeForTool(latest.notice) : NOT_CONNECTED_MESSAGE);
+          if (latest.notice) {
+            await throwAuthNotice(input, latest.notice, deps);
+          }
+          throw new Error(NOT_CONNECTED_MESSAGE);
         }
 
         if (error.code === "unauthorized") {

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -220,6 +220,28 @@ function noticeMessage(notice: AuthNotice) {
   return `The local Supabase auth file was corrupted, so auth was reset.\n\nThe corrupted file was preserved here:\n${notice.backupPath}\n\nReconnect to continue.`;
 }
 
+async function checkNoticeAfterCallback(context: Pick<AuthFlowContext, "api" | "setState">): Promise<boolean> {
+  try {
+    const authResponse = (await context.api.client.provider.oauth.authorize({
+      providerID: "supabase",
+      method: 1,
+    })) as ApiResponse<AuthData>;
+
+    if (authResponse.error || !authResponse.data?.instructions) {
+      return false;
+    }
+
+    const status = parseAuthStatus(authResponse.data.instructions);
+    if (status.status === "disconnected" && status.notice) {
+      context.setState({ type: "notice", notice: status.notice });
+      return true;
+    }
+  } catch {
+    // ignore secondary errors
+  }
+  return false;
+}
+
 async function openBrowser(url: string, logger: SupabaseLogger) {
   try {
     const open = await import("open");
@@ -416,6 +438,7 @@ export async function runAuthPreflight(context: Pick<AuthFlowContext, "api" | "l
     })) as ApiResponse<boolean>;
 
     if (callbackResponse.error) {
+      if (await checkNoticeAfterCallback(context)) return;
       throw new Error(formatAuthError("callback", callbackResponse.error));
     }
 
@@ -424,8 +447,10 @@ export async function runAuthPreflight(context: Pick<AuthFlowContext, "api" | "l
       return;
     }
 
+    if (await checkNoticeAfterCallback(context)) return;
     context.setState({ type: "idle" });
   } catch (error) {
+    if (await checkNoticeAfterCallback(context)) return;
     context.setState({
       type: "unknown",
       message: formatAuthError("unknown", error),

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -37,6 +37,7 @@ type OAuthState =
   | { type: "checking_auth" }
   | { type: "idle" }
   | { type: "already_connected" }
+  | { type: "notice"; notice: AuthNotice }
   | { type: "authorizing"; url: string }
   | { type: "waiting_callback"; url: string }
   | { type: "success" }
@@ -53,8 +54,14 @@ type AuthData = {
 
 type AuthStatus =
   | { status: "connected"; checked: boolean }
-  | { status: "disconnected"; checked: boolean }
+  | { status: "disconnected"; checked: boolean; notice?: AuthNotice }
   | { status: "refresh_required"; checked: true };
+
+type AuthNotice = {
+  type: "auth_store_reset";
+  message: string;
+  backupPath: string;
+};
 
 type AuthFlowContext = {
   api: TuiPluginApi;
@@ -169,17 +176,48 @@ function SupabaseSpinnerDialog(props: {
   ), { onClose: props.dismissible ? props.onClose : () => undefined });
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseAuthNotice(value: unknown): AuthNotice | undefined {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+
+  if (value.type === "auth_store_reset" && typeof value.message === "string" && typeof value.backupPath === "string") {
+    return {
+      type: "auth_store_reset",
+      message: value.message,
+      backupPath: value.backupPath,
+    };
+  }
+
+  return undefined;
+}
+
 function parseAuthStatus(instructions: string): AuthStatus {
   const parsed = JSON.parse(instructions) as Partial<AuthStatus>;
   if (
     parsed.status === "connected" ||
-    parsed.status === "disconnected" ||
     parsed.status === "refresh_required"
   ) {
     return parsed as AuthStatus;
   }
 
+  if (parsed.status === "disconnected") {
+    return {
+      status: "disconnected",
+      checked: parsed.checked === true,
+      notice: parseAuthNotice(parsed.notice),
+    };
+  }
+
   throw new Error("Invalid Supabase auth status response");
+}
+
+function noticeMessage(notice: AuthNotice) {
+  return `The local Supabase auth file was corrupted, so auth was reset.\n\nThe corrupted file was preserved here:\n${notice.backupPath}\n\nReconnect to continue.`;
 }
 
 async function openBrowser(url: string, logger: SupabaseLogger) {
@@ -363,6 +401,11 @@ export async function runAuthPreflight(context: Pick<AuthFlowContext, "api" | "l
     }
 
     if (status.status === "disconnected") {
+      if (status.notice) {
+        context.setState({ type: "notice", notice: status.notice });
+        return;
+      }
+
       context.setState({ type: "idle" });
       return;
     }
@@ -515,6 +558,15 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
     return props.api.ui.DialogConfirm({
       title: "Connect your Supabase account",
       message: "Open your browser to authorize OpenCode to access your Supabase account.",
+      onConfirm: startOAuth,
+      onCancel: closeDialog,
+    });
+  }
+
+  if (currentState.type === "notice") {
+    return props.api.ui.DialogConfirm({
+      title: "Supabase auth reset",
+      message: noticeMessage(currentState.notice),
       onConfirm: startOAuth,
       onCancel: closeDialog,
     });

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -814,6 +814,157 @@ test("supabase auth preflight shows unknown state when refresh verification fail
   ]);
 });
 
+test("supabase auth preflight surfaces notice after refresh callback error", async () => {
+  const states: Array<Record<string, unknown>> = [];
+  const notice = {
+    type: "auth_store_reset",
+    message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+    backupPath: "/tmp/project/.opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+  };
+  let authorizeCalls = 0;
+  const api = createDialogApi({
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method?: number }) => {
+            authorizeCalls += 1;
+            if (method === 1) {
+              if (authorizeCalls === 1) {
+                return Promise.resolve({
+                  data: {
+                    url: "https://supabase.com/",
+                    instructions: JSON.stringify({ status: "refresh_required", checked: true }),
+                    method: "auto",
+                  },
+                });
+              }
+              return Promise.resolve({
+                data: {
+                  url: "https://supabase.com/",
+                  instructions: JSON.stringify({ status: "disconnected", checked: false, notice }),
+                  method: "auto",
+                },
+              });
+            }
+            return Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } });
+          },
+          callback: ({ method }: { method?: number }) => {
+            if (method === 1) {
+              return Promise.resolve({
+                error: {
+                  data: {
+                    name: "UnknownError",
+                    data: {
+                      message: "Supabase auth refresh failed: broker unavailable",
+                    },
+                  },
+                  errors: [],
+                  success: false,
+                },
+              });
+            }
+            return Promise.resolve({ data: true });
+          },
+        },
+      },
+    },
+  });
+
+  await runAuthPreflight({
+    api: api as never,
+    logger: createLogger(),
+    setState: (state) => {
+      states.push(state as unknown as Record<string, unknown>);
+    },
+  });
+
+  expect(states).toEqual([
+    { type: "checking_auth" },
+    { type: "notice", notice },
+  ]);
+});
+
+test("supabase auth preflight surfaces notice after refresh callback false", async () => {
+  const states: Array<Record<string, unknown>> = [];
+  const notice = {
+    type: "auth_store_reset",
+    message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+    backupPath: "/tmp/project/.opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+  };
+  let authorizeCalls = 0;
+  const api = createDialogApi({
+    client: {
+      app: {
+        log: (_input: unknown) => Promise.resolve(true),
+      },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method?: number }) => {
+            authorizeCalls += 1;
+            if (method === 1) {
+              if (authorizeCalls === 1) {
+                return Promise.resolve({
+                  data: {
+                    url: "https://supabase.com/",
+                    instructions: JSON.stringify({ status: "refresh_required", checked: true }),
+                    method: "auto",
+                  },
+                });
+              }
+              return Promise.resolve({
+                data: {
+                  url: "https://supabase.com/",
+                  instructions: JSON.stringify({ status: "disconnected", checked: false, notice }),
+                  method: "auto",
+                },
+              });
+            }
+            return Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } });
+          },
+          callback: ({ method }: { method?: number }) => {
+            if (method === 1) {
+              return Promise.resolve({ data: false });
+            }
+            return Promise.resolve({ data: true });
+          },
+        },
+      },
+    },
+  });
+
+  await runAuthPreflight({
+    api: api as never,
+    logger: createLogger(),
+    setState: (state) => {
+      states.push(state as unknown as Record<string, unknown>);
+    },
+  });
+
+  expect(states).toEqual([
+    { type: "checking_auth" },
+    { type: "notice", notice },
+  ]);
+});
+
 test("supabase dialog already connected offers disconnect action", async () => {
   const authorizeCalls: Array<{ providerID?: string; method?: number; inputs?: Record<string, string> }> = [];
   const api = createDialogApi({

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -643,6 +643,109 @@ test("supabase auth preflight reports already connected when saved auth is still
   expect(states).toEqual([{ type: "checking_auth" }, { type: "already_connected" }]);
 });
 
+test("supabase auth preflight surfaces corrupt-store notice", async () => {
+  const states: Array<Record<string, unknown>> = [];
+  const notice = {
+    type: "auth_store_reset",
+    message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+    backupPath: "/tmp/project/.opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+  };
+  const api = createDialogApi({
+    client: {
+      app: { log: (_input: unknown) => Promise.resolve(true) },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: { promptAsync: () => Promise.resolve({ data: true }) },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method?: number }) => {
+            if (method === 1) {
+              return Promise.resolve({
+                data: {
+                  url: "https://supabase.com/",
+                  instructions: JSON.stringify({ status: "disconnected", checked: false, notice }),
+                  method: "code",
+                },
+              });
+            }
+            return Promise.resolve({ data: { url: "https://example.com/auth", instructions: "Test", method: "manual" } });
+          },
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  });
+
+  await runAuthPreflight({
+    api: api as never,
+    logger: createLogger(),
+    setState: (state) => {
+      states.push(state as unknown as Record<string, unknown>);
+    },
+  });
+
+  expect(states).toEqual([{ type: "checking_auth" }, { type: "notice", notice }]);
+});
+
+test("supabase dialog notice shows backup path and reconnect action", async () => {
+  let authorizeCalls = 0;
+  const api = createDialogApi({
+    client: {
+      app: { log: (_input: unknown) => Promise.resolve(true) },
+      tui: {
+        clearPrompt: () => Promise.resolve({ data: true }),
+        appendPrompt: (_input: unknown) => Promise.resolve({ data: true }),
+        submitPrompt: () => Promise.resolve({ data: true }),
+      },
+      session: {
+        create: () => Promise.resolve({ data: { id: "ses-notice" } }),
+        promptAsync: () => Promise.resolve({ data: true }),
+      },
+      provider: {
+        oauth: {
+          authorize: ({ method }: { method?: number }) => {
+            authorizeCalls += 1;
+            return Promise.resolve({
+              data: {
+                url: method === 1 ? "https://supabase.com/" : "https://example.com/auth",
+                instructions: method === 1 ? JSON.stringify({ status: "disconnected", checked: false }) : "Test",
+                method: "manual",
+              },
+            });
+          },
+          callback: () => Promise.resolve({ data: true }),
+        },
+      },
+    },
+  });
+  const backupPath = "/tmp/project/.opencode/supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json";
+
+  const dialog = SupabaseDialog({
+    api: api as never,
+    logger: createLogger(),
+    onClose: () => api.ui.dialog.clear(),
+    initialState: {
+      type: "notice",
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath,
+      },
+    },
+  }) as { title?: string; message?: string; onConfirm?: () => Promise<void>; onCancel?: () => void };
+
+  expect(dialog.title).toBe("Supabase auth reset");
+  expect(dialog.message).toContain("local Supabase auth file was corrupted");
+  expect(dialog.message).toContain(backupPath);
+
+  await dialog.onConfirm?.();
+
+  expect(authorizeCalls).toBe(1);
+});
+
 test("supabase auth preflight shows unknown state when refresh verification fails", async () => {
   const states: Array<Record<string, unknown>> = [];
   const api = createDialogApi({

--- a/test/server-auth.test.ts
+++ b/test/server-auth.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
 import { createSupabaseAuth, stopSupabaseAuthServer } from "../src/server/auth.ts";
-import { readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
+import { readSavedAuth, writeSavedAuth, writeSavedAuthNotice } from "../src/server/store.ts";
 import { createSupabaseLogger } from "../src/shared/log.ts";
 import type { FetchLike } from "../src/shared/types.ts";
 
@@ -89,6 +89,29 @@ describe("server auth hook", () => {
     expect(JSON.parse(result.instructions)).toEqual({
       status: "disconnected",
       checked: false,
+    });
+  });
+
+  test("status method reports disconnected notice when auth store was reset", async () => {
+    const input = await createInput();
+    const backupPath = join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json");
+    await writeSavedAuthNotice(input as never, {
+      type: "auth_store_reset",
+      message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+      backupPath,
+    });
+
+    const auth = createSupabaseAuth(input as never);
+    const result = await secondAuthMethod(auth).authorize();
+
+    expect(JSON.parse(result.instructions)).toEqual({
+      status: "disconnected",
+      checked: false,
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath,
+      },
     });
   });
 

--- a/test/server-store.test.ts
+++ b/test/server-store.test.ts
@@ -339,6 +339,36 @@ describe("server auth store", () => {
     await expect(Bun.file(lockPath).exists()).resolves.toBe(false);
   });
 
+  test("takes over a malformed recovery lock and performs recovery", async () => {
+    const input = await createInput();
+    const path = await writeRawStore(input, "{ not json");
+    const lockPath = `${path}.recovering.lock`;
+    await mkdir(dirname(lockPath), { recursive: true });
+    await writeFile(lockPath, JSON.stringify({ startedAt: "not-a-number", token: "bad-owner" }));
+
+    const backupPath = join(
+      input.worktree,
+      ".opencode",
+      "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+    );
+
+    const state = await readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    });
+
+    expect(state).toEqual({
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath,
+      },
+    });
+
+    await expect(readFile(backupPath, "utf8")).resolves.toBe("{ not json");
+    await expect(Bun.file(lockPath).exists()).resolves.toBe(false);
+  });
+
   test("stores auth in a plugin-owned file under the worktree .opencode directory", async () => {
     const input = await createInput();
 

--- a/test/server-store.test.ts
+++ b/test/server-store.test.ts
@@ -68,6 +68,41 @@ describe("server auth store", () => {
     expect(warn).toHaveBeenCalledTimes(1);
   });
 
+  test("concurrent corrupt-store reads share one recovery", async () => {
+    const input = await createInput();
+    const path = await writeRawStore(input, "{ not json");
+    const warn = mock(async () => undefined);
+    const backupPath = join(
+      input.worktree,
+      ".opencode",
+      "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+    );
+    const deps = {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+      logger: { warn },
+    };
+
+    const [a, b] = await Promise.all([
+      readSavedAuth(input, deps),
+      readSavedAuth(input, deps),
+    ]);
+
+    const expected = {
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath,
+      },
+    };
+    expect(a).toEqual(expected);
+    expect(b).toEqual(expected);
+
+    await expect(readFile(path, "utf8")).resolves.toContain("auth_store_reset");
+    await expect(readFile(backupPath, "utf8")).resolves.toBe("{ not json");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
   test("backs up an unsupported store version and resets the auth store", async () => {
     const input = await createInput();
     await writeRawStore(input, JSON.stringify({ version: 2, auth: { access: "a", refresh: "r", expires: 1 } }));

--- a/test/server-store.test.ts
+++ b/test/server-store.test.ts
@@ -227,7 +227,8 @@ describe("server auth store", () => {
     const path = await writeRawStore(input, "{ not json");
     const lockPath = `${path}.recovering.lock`;
     await mkdir(dirname(lockPath), { recursive: true });
-    await writeFile(lockPath, "");
+    // Write a lock with recent startedAt to simulate an active process
+    await writeFile(lockPath, JSON.stringify({ startedAt: Date.now() }));
 
     const readPromise = readSavedAuth(input, {
       now: () => new Date("2026-05-11T10:20:30.000Z"),
@@ -248,6 +249,94 @@ describe("server auth store", () => {
     await rm(lockPath, { force: true });
 
     await expect(readPromise).resolves.toEqual(recoveredState);
+  });
+
+  test("recovers again after waiting-on-lock read completes", async () => {
+    const input = await createInput();
+    const path = await writeRawStore(input, "{ not json");
+    const lockPath = `${path}.recovering.lock`;
+    await mkdir(dirname(lockPath), { recursive: true });
+    await writeFile(lockPath, JSON.stringify({ startedAt: Date.now() }));
+
+    const readPromise = readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    });
+
+    // simulate another process finishing recovery
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const backupPath = join(
+      input.worktree,
+      ".opencode",
+      "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+    );
+    const recoveredState: SavedState = {
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath,
+      },
+    };
+    await writeFile(path, JSON.stringify(recoveredState));
+    await rm(lockPath, { force: true });
+
+    await expect(readPromise).resolves.toEqual(recoveredState);
+
+    // corrupt again and recover a second time to prove inFlightRecoveries was cleaned up
+    await writeRawStore(input, "also not json");
+    const secondBackupPath = join(
+      input.worktree,
+      ".opencode",
+      "supabase-auth.corrupt-2026-05-11T10-20-31-000Z.json",
+    );
+
+    const secondState = await readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:31.000Z"),
+    });
+
+    expect(secondState).toEqual({
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath: secondBackupPath,
+      },
+    });
+
+    await expect(readFile(secondBackupPath, "utf8")).resolves.toBe("also not json");
+  });
+
+  test("takes over a stale recovery lock and performs recovery", async () => {
+    const input = await createInput();
+    const path = await writeRawStore(input, "{ not json");
+    const lockPath = `${path}.recovering.lock`;
+    await mkdir(dirname(lockPath), { recursive: true });
+    // Write a stale lock (startedAt far in the past relative to real wall clock)
+    const staleStartedAt = Date.now() - 20_000;
+    await writeFile(lockPath, JSON.stringify({ startedAt: staleStartedAt, token: "stale-owner" }));
+
+    const backupPath = join(
+      input.worktree,
+      ".opencode",
+      "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+    );
+
+    const state = await readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    });
+
+    expect(state).toEqual({
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath,
+      },
+    });
+
+    await expect(readFile(path, "utf8")).resolves.toContain("auth_store_reset");
+    await expect(readFile(backupPath, "utf8")).resolves.toBe("{ not json");
+    await expect(Bun.file(lockPath).exists()).resolves.toBe(false);
   });
 
   test("stores auth in a plugin-owned file under the worktree .opencode directory", async () => {

--- a/test/server-store.test.ts
+++ b/test/server-store.test.ts
@@ -251,6 +251,33 @@ describe("server auth store", () => {
     await expect(readPromise).resolves.toEqual(recoveredState);
   });
 
+  test("waits for another process when store is temporarily missing under recovery lock", async () => {
+    const input = await createInput();
+    const path = getStoreFile(input);
+    const lockPath = `${path}.recovering.lock`;
+    await mkdir(dirname(lockPath), { recursive: true });
+    await writeFile(lockPath, JSON.stringify({ startedAt: Date.now() }));
+
+    const readPromise = readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const backupPath = join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json");
+    const recoveredState: SavedState = {
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath,
+      },
+    };
+    await writeFile(path, JSON.stringify(recoveredState));
+    await rm(lockPath, { force: true });
+
+    await expect(readPromise).resolves.toEqual(recoveredState);
+  });
+
   test("recovers again after waiting-on-lock read completes", async () => {
     const input = await createInput();
     const path = await writeRawStore(input, "{ not json");

--- a/test/server-store.test.ts
+++ b/test/server-store.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 
 import {
+  type SavedState,
   clearSavedAuth,
   getStoreFile,
   readSavedAuth,
@@ -87,7 +88,7 @@ describe("server auth store", () => {
       readSavedAuth(input, deps),
     ]);
 
-    const expected = {
+    const expected: SavedState = {
       version: 1,
       notice: {
         type: "auth_store_reset",
@@ -198,6 +199,55 @@ describe("server auth store", () => {
     });
     await clearSavedAuth(input);
     await expect(readSavedAuth(input)).resolves.toEqual({ version: 1 });
+  });
+
+  test("avoids overwriting an existing backup by appending a counter", async () => {
+    const input = await createInput();
+    const path = await writeRawStore(input, "{ not json");
+    const existingBackup = join(
+      input.worktree,
+      ".opencode",
+      "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+    );
+    await mkdir(dirname(existingBackup), { recursive: true });
+    await writeFile(existingBackup, "existing backup");
+
+    const state = await readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    });
+
+    expect(state.notice?.backupPath).toBe(
+      join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z-1.json"),
+    );
+    await expect(readFile(existingBackup, "utf8")).resolves.toBe("existing backup");
+  });
+
+  test("waits for another process to recover when lock is held", async () => {
+    const input = await createInput();
+    const path = await writeRawStore(input, "{ not json");
+    const lockPath = `${path}.recovering.lock`;
+    await mkdir(dirname(lockPath), { recursive: true });
+    await writeFile(lockPath, "");
+
+    const readPromise = readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    });
+
+    // simulate another process finishing recovery
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    const backupPath = join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json");
+    const recoveredState: SavedState = {
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath,
+      },
+    };
+    await writeFile(path, JSON.stringify(recoveredState));
+    await rm(lockPath, { force: true });
+
+    await expect(readPromise).resolves.toEqual(recoveredState);
   });
 
   test("stores auth in a plugin-owned file under the worktree .opencode directory", async () => {

--- a/test/server-store.test.ts
+++ b/test/server-store.test.ts
@@ -1,9 +1,15 @@
-import { afterEach, describe, expect, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { afterEach, describe, expect, mock, test } from "bun:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 
-import { clearSavedAuth, getStoreFile, readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
+import {
+  clearSavedAuth,
+  getStoreFile,
+  readSavedAuth,
+  writeSavedAuth,
+  writeSavedAuthNotice,
+} from "../src/server/store.ts";
 
 type PluginLikeInput = {
   directory: string;
@@ -21,11 +27,144 @@ async function createInput(): Promise<PluginLikeInput> {
   };
 }
 
+async function writeRawStore(input: PluginLikeInput, contents: string) {
+  const path = getStoreFile(input);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents);
+  return path;
+}
+
 afterEach(async () => {
   await Promise.all(cleanupPaths.splice(0).map((path) => rm(path, { force: true, recursive: true })));
 });
 
 describe("server auth store", () => {
+  test("backs up invalid JSON and resets the auth store with a notice", async () => {
+    const input = await createInput();
+    const path = await writeRawStore(input, "{ not json");
+    const warn = mock(async () => undefined);
+    const backupPath = join(
+      input.worktree,
+      ".opencode",
+      "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json",
+    );
+
+    await expect(
+      readSavedAuth(input, {
+        now: () => new Date("2026-05-11T10:20:30.000Z"),
+        logger: { warn },
+      }),
+    ).resolves.toEqual({
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+        backupPath,
+      },
+    });
+
+    await expect(readFile(path, "utf8")).resolves.toContain("auth_store_reset");
+    await expect(readFile(backupPath, "utf8")).resolves.toBe("{ not json");
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  test("backs up an unsupported store version and resets the auth store", async () => {
+    const input = await createInput();
+    await writeRawStore(input, JSON.stringify({ version: 2, auth: { access: "a", refresh: "r", expires: 1 } }));
+
+    const state = await readSavedAuth(input, {
+      now: () => new Date("2026-05-11T10:20:30.000Z"),
+    });
+
+    expect(state).toMatchObject({
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        backupPath: join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json"),
+      },
+    });
+  });
+
+  test("backs up a wrong top-level shape and resets the auth store", async () => {
+    const input = await createInput();
+    await writeRawStore(input, JSON.stringify(["not", "an", "object"]));
+
+    await expect(
+      readSavedAuth(input, {
+        now: () => new Date("2026-05-11T10:20:30.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        backupPath: join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json"),
+      },
+    });
+  });
+
+  test("backs up a wrong auth shape and resets the auth store", async () => {
+    const input = await createInput();
+    await writeRawStore(input, JSON.stringify({ version: 1, auth: { access: "a", refresh: "r", expires: "soon" } }));
+
+    await expect(
+      readSavedAuth(input, {
+        now: () => new Date("2026-05-11T10:20:30.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+      },
+    });
+  });
+
+  test("backs up an invalid persisted notice shape and resets the auth store", async () => {
+    const input = await createInput();
+    await writeRawStore(input, JSON.stringify({ version: 1, notice: { type: "auth_store_reset" } }));
+
+    await expect(
+      readSavedAuth(input, {
+        now: () => new Date("2026-05-11T10:20:30.000Z"),
+      }),
+    ).resolves.toMatchObject({
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+      },
+    });
+  });
+
+  test("successful auth writes and explicit clears remove persisted notices", async () => {
+    const input = await createInput();
+    await writeSavedAuthNotice(input, {
+      type: "auth_store_reset",
+      message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+      backupPath: join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json"),
+    });
+
+    await writeSavedAuth(input, {
+      access: "access-token",
+      refresh: "saved-refresh",
+      expires: 12345,
+    });
+    await expect(readSavedAuth(input)).resolves.toEqual({
+      version: 1,
+      auth: {
+        access: "access-token",
+        refresh: "saved-refresh",
+        expires: 12345,
+      },
+    });
+
+    await writeSavedAuthNotice(input, {
+      type: "auth_store_reset",
+      message: "Supabase auth was reset because the local auth store was corrupted. Reconnect to continue.",
+      backupPath: join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json"),
+    });
+    await clearSavedAuth(input);
+    await expect(readSavedAuth(input)).resolves.toEqual({ version: 1 });
+  });
+
   test("stores auth in a plugin-owned file under the worktree .opencode directory", async () => {
     const input = await createInput();
 

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, mock, test } from "bun:test";
-import { mkdtemp, rm } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { dirname, join, resolve } from "node:path";
 import type { ToolContext } from "@opencode-ai/plugin/tool";
 
-import { readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
+import { getStoreFile, readSavedAuth, writeSavedAuth } from "../src/server/store.ts";
 import {
   type SupabaseToolInput,
   createSupabaseTools,
@@ -48,6 +48,13 @@ async function createInput(): Promise<TestFixtures> {
   } satisfies TestPluginInput;
 
   return { hostAuthSet, input };
+}
+
+async function writeRawStore(input: TestPluginInput, contents: string) {
+  const path = getStoreFile(input);
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, contents);
+  return path;
 }
 
 function createContext(input: TestPluginInput): TestToolContext {
@@ -189,6 +196,36 @@ describe("server tools auth helper", () => {
         { fetch: mock(async () => new Response("unexpected")) },
       ),
     ).rejects.toThrow("Supabase is not connected. Run /supabase first.");
+  });
+
+  test("tool auth reports corrupt store recovery with backup path", async () => {
+    const { input } = await createInput();
+    await writeRawStore(input, "{ not json");
+    const backupPath = join(input.worktree, ".opencode", "supabase-auth.corrupt-2026-05-11T10-20-30-000Z.json");
+
+    await expect(
+      ensureSupabaseToolAuth(
+        input,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17670,
+        },
+        {
+          fetch: mock(async () => new Response("unexpected")),
+          now: () => new Date("2026-05-11T10:20:30.000Z"),
+        },
+      ),
+    ).rejects.toThrow(
+      `Supabase auth was reset because the local auth store was corrupted.\n\nThe corrupted file was preserved here:\n${backupPath}\n\nRun /supabase to reconnect, then retry this tool.`,
+    );
+
+    await expect(readSavedAuth(input)).resolves.toMatchObject({
+      version: 1,
+      notice: {
+        type: "auth_store_reset",
+        backupPath,
+      },
+    });
   });
 
   test("updates host auth after a successful refresh", async () => {

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -1060,6 +1060,105 @@ describe("server tools auth helper", () => {
     expect(hostClearCalls).toBe(2);
   });
 
+  test("shared reset-notice refresh rejection clears host auth for each joined directory", async () => {
+    const root = await mkdtemp(join(tmpdir(), "opencode-supabase-tools-"));
+    cleanupPaths.push(root);
+    const firstInput = {
+      client: {
+        auth: {
+          set: mock(async () => ({ data: true })),
+        },
+      },
+      directory: join(root, "consumer-a"),
+      worktree: root,
+      serverUrl: new URL("http://127.0.0.1:7777/"),
+    } satisfies TestPluginInput;
+    const secondInput = {
+      client: {
+        auth: {
+          set: mock(async () => ({ data: true })),
+        },
+      },
+      directory: join(root, "consumer-b"),
+      worktree: root,
+      serverUrl: new URL("http://127.0.0.1:7777/"),
+    } satisfies TestPluginInput;
+
+    process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";
+    await writeSavedAuth(firstInput, {
+      access: "expired-access",
+      refresh: "saved-refresh",
+      expires: Date.now() - 1_000,
+    });
+
+    let brokerRefreshCalls = 0;
+    let hostClearCalls = 0;
+    const fetchMock: FetchLike = mock(async (request, init) => {
+      const url = String(request);
+      if (url === "https://example.com/broker/refresh") {
+        brokerRefreshCalls += 1;
+        await writeRawStore(firstInput, "{ not json");
+        return new Response(
+          JSON.stringify({
+            error: {
+              code: "invalid_request",
+              message: "broker rejected malformed refresh request",
+            },
+          }),
+          {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
+      }
+
+      if (url.startsWith("http://127.0.0.1:7777/auth/supabase?directory=")) {
+        expect(init?.method).toBe("DELETE");
+        hostClearCalls += 1;
+        return new Response(null, { status: 204 });
+      }
+
+      throw new Error(`Unexpected fetch ${url}`);
+    });
+
+    const results = await Promise.allSettled([
+      ensureSupabaseToolAuth(
+        firstInput,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17686,
+        },
+        { fetch: fetchMock, now: () => new Date("2026-05-11T10:20:30.000Z") },
+      ),
+      ensureSupabaseToolAuth(
+        secondInput,
+        {
+          clientId: "plugin-client",
+          oauthPort: 17686,
+        },
+        { fetch: fetchMock, now: () => new Date("2026-05-11T10:20:30.000Z") },
+      ),
+    ]);
+
+    expect(results).toEqual([
+      expect.objectContaining({
+        reason: expect.objectContaining({
+          message: expect.stringContaining("Supabase auth was reset because the local auth store was corrupted."),
+        }),
+        status: "rejected",
+      }),
+      expect.objectContaining({
+        reason: expect.objectContaining({
+          message: expect.stringContaining("Supabase auth was reset because the local auth store was corrupted."),
+        }),
+        status: "rejected",
+      }),
+    ]);
+
+    expect(brokerRefreshCalls).toBe(1);
+    expect(hostClearCalls).toBe(2);
+  });
+
   test("refreshes session-scoped auth when worktree is unrelated", async () => {
     const { hostAuthSet, input } = await createInput();
     process.env.OPENCODE_SUPABASE_BROKER_URL = "https://example.com/broker";


### PR DESCRIPTION
## Summary

- Corrupted `supabase-auth.json` is detected, backed up to `.opencode/supabase-auth.corrupt-<timestamp>.json`, and the canonical store reset to a clean empty state with a persistent recovery notice
- `/supabase` dialog surfaces a persistent reconnect prompt with the backup path when a corruption notice is present
- Direct tool calls show a clear reconnect error message with the backup path instead of a generic "not connected" message
- Storage and auth status APIs include corruption notices in their responses
- Notice persists until explicit reconnect (write) or disconnect (clear)

## Test Plan

- [x] Invalid JSON backs up and resets with notice
- [x] Unsupported version, wrong top-level shape, and wrong auth shape trigger recovery
- [x] Successful auth write and explicit clear remove corruption notices
- [x] Tool auth surfaces corruption notice with backup path
- [x] Auth status instructions include corruption notice on disconnect
- [x] TUI preflight maps corruption notice to reconnect dialog
- [x] TUI dialog shows backup path and reconnect action
- [x] Full test suite passes: `168 pass, 0 fail`
- [x] Typecheck and lint pass

Closes #34