### PR TITLE
fix: tighten Supabase MCP onboarding copy

### DIFF
--- a/.changeset/quiet-dingos-connect.md
+++ b/.changeset/quiet-dingos-connect.md
@@ -1,0 +1,5 @@
+---
+"opencode-supabase": patch
+---
+
+Tighten Supabase MCP onboarding copy to guide users from listing projects into MCP connection.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ List my Supabase projects
 
 Pick the project you want to work with, then ask OpenCode to connect Supabase MCP for that project. OpenCode opens Supabase Studio so you can choose MCP permissions and copy the generated OpenCode config.
 
-After OpenCode adds the config, restart OpenCode and authenticate the MCP server:
+After config is added, restart OpenCode and authenticate the MCP server:
 
 ```bash
 opencode mcp auth supabase

--- a/README.md
+++ b/README.md
@@ -32,25 +32,21 @@ No separate `skills` CLI setup is required. Installing the plugin makes these sk
 
 ## Supabase MCP Onboarding
 
-Ask your agent:
+After connecting Supabase, start by asking OpenCode to list projects:
 
 ```text
-Set up Supabase MCP for my project
+List my Supabase projects
 ```
 
-The agent can explain Supabase MCP, help you choose the target project, and open the Supabase Studio Connect Sheet with the MCP tab and OpenCode client selected.
+Pick the project you want to work with, then ask OpenCode to connect Supabase MCP for that project. OpenCode opens Supabase Studio so you can choose MCP permissions and copy the generated OpenCode config.
 
-Studio remains the source of truth for MCP feature groups, permissions, generated OpenCode config, and auth steps. If you want help applying the Studio output to this repository, paste the Studio prompt or OpenCode config snippet back into OpenCode.
-
-You can skip any Studio instruction to install Supabase Agent Skills separately. This plugin already bundles Supabase skills.
-
-After changing OpenCode MCP config, restart OpenCode. If OAuth is not prompted automatically, run:
+After OpenCode adds the config, restart OpenCode and authenticate the MCP server:
 
 ```bash
 opencode mcp auth supabase
 ```
 
-This plugin opens the MCP setup page and guides the workflow. It does not automatically edit MCP config or choose read-only/feature-group settings for you.
+Complete OAuth in the browser. Skip any `install Supabase Agent Skills` step in Studio; this plugin already bundles the Supabase skills.
 
 ### Disable Bundled Skills
 

--- a/docs/superpowers/plans/2026-05-19-mcp-onboarding-copy-cleanup.md
+++ b/docs/superpowers/plans/2026-05-19-mcp-onboarding-copy-cleanup.md
@@ -1,0 +1,555 @@
+# MCP Onboarding Copy Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Tighten Supabase MCP onboarding copy so users first list projects, then connect MCP, then restart OpenCode and run `opencode mcp auth supabase` explicitly.
+
+**Architecture:** This is a small copy and guidance change. Keep behavior unchanged: no new tools, no MCP status tool, no config API integration, and no no-restart flow. Update source copy, guide instructions, README docs, and tests that assert exact strings.
+
+**Tech Stack:** TypeScript, Bun test runner, OpenCode plugin tools, Markdown skill docs, React TUI strings.
+
+---
+
+## File Structure
+
+- Modify `src/tui/dialog.tsx`: first-run TUI onboarding and post-auth dialog copy.
+- Modify `src/server/auth-html.ts`: browser success page prompt copy if needed for exact alignment.
+- Modify `src/server/tools.ts`: `supabase_open_mcp_setup` tool description and `formatMcpSetupResult()` output.
+- Modify `skills/opencode-supabase-guide/SKILL.md`: agent guidance for ordering, Question tool examples, and explicit MCP auth steps.
+- Modify `README.md`: user-facing MCP onboarding docs.
+- Modify `test/plugin-exports.test.ts`: exact copy assertions for onboarding, post-auth, and HTML success output.
+- Modify `test/server-tools.test.ts`: exact output assertions for `supabase_open_mcp_setup`.
+
+## Scope Constraints
+
+- Do not add `supabase_mcp_status` in this PR.
+- Do not implement no-restart MCP config reload or OAuth triggering.
+- Do not parse OpenCode config to detect existing MCP servers.
+- Do not say OAuth might be prompted automatically. OpenCode currently detects `needs_auth` but does not auto-start browser OAuth.
+- Keep `supabase_open_mcp_setup` return value as human-readable text, not JSON.
+
+### Task 1: Align First-Run Copy Around Listing Projects
+
+**Files:**
+- Modify: `test/plugin-exports.test.ts`
+- Modify: `src/tui/dialog.tsx`
+- Modify: `src/server/auth-html.ts`
+
+- [ ] **Step 1: Update failing tests for onboarding prompt**
+
+In `test/plugin-exports.test.ts`, find the test that asserts `ONBOARDING_MESSAGE`. Change the expected onboarding text so `Try this:` uses project listing, not MCP setup.
+
+Expected assertion content:
+
+```ts
+expect(plugin.ONBOARDING_MESSAGE).toContain("Supabase is connected.")
+expect(plugin.ONBOARDING_MESSAGE).toContain("Try this:")
+expect(plugin.ONBOARDING_MESSAGE).toContain("List my Supabase projects")
+expect(plugin.ONBOARDING_MESSAGE).not.toContain("Set up Supabase MCP for my project")
+```
+
+If the existing test uses one exact multiline string, update the exact string to:
+
+```text
+Supabase is connected.
+
+Start by listing your Supabase projects, then connect project-scoped MCP tools for database inspection, docs, advisors, and more in OpenCode.
+
+You can also ask about:
+- organizations and projects
+- API keys
+- regions
+- creating a new project
+
+Try this:
+List my Supabase projects
+```
+
+- [ ] **Step 2: Update failing tests for auth success copy**
+
+In `test/plugin-exports.test.ts`, keep or update the final success dialog assertion to this exact sentence:
+
+```ts
+expect(message).toContain("Your account is ready. Close this dialog and ask me to list your Supabase projects.")
+```
+
+Keep the HTML success assertion aligned with lowercase browser prompt:
+
+```ts
+expect(html).toContain("list my Supabase projects")
+```
+
+- [ ] **Step 3: Run focused test to verify failures**
+
+Run:
+
+```bash
+bun run test test/plugin-exports.test.ts
+```
+
+Expected: FAIL because source copy still contains MCP-first onboarding text.
+
+- [ ] **Step 4: Update TUI onboarding source copy**
+
+In `src/tui/dialog.tsx`, change `ONBOARDING_MESSAGE` to:
+
+```ts
+export const ONBOARDING_MESSAGE = `Supabase is connected.
+
+Start by listing your Supabase projects, then connect project-scoped MCP tools for database inspection, docs, advisors, and more in OpenCode.
+
+You can also ask about:
+- organizations and projects
+- API keys
+- regions
+- creating a new project
+
+Try this:
+List my Supabase projects`
+```
+
+Keep the post-auth success dialog sentence as:
+
+```ts
+message: "Your account is ready. Close this dialog and ask me to list your Supabase projects.",
+```
+
+- [ ] **Step 5: Verify browser success source copy**
+
+In `src/server/auth-html.ts`, keep the prompt box as:
+
+```ts
+list my Supabase projects
+```
+
+If the surrounding text competes with this direction, make it match:
+
+```html
+<div class="label">Try this next:</div>
+<div class="prompt">list my Supabase projects</div>
+```
+
+- [ ] **Step 6: Run focused test to verify pass**
+
+Run:
+
+```bash
+bun run test test/plugin-exports.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit Task 1**
+
+Run:
+
+```bash
+git add src/tui/dialog.tsx src/server/auth-html.ts test/plugin-exports.test.ts
+git commit -m "fix(tui): lead Supabase onboarding with projects"
+```
+
+Expected: commit succeeds. If `src/server/auth-html.ts` did not change, omit it from `git add`.
+
+### Task 2: Simplify MCP Setup Tool Output
+
+**Files:**
+- Modify: `test/server-tools.test.ts`
+- Modify: `src/server/tools.ts`
+
+- [ ] **Step 1: Update failing tests for setup output**
+
+In `test/server-tools.test.ts`, find the `supabase_open_mcp_setup` output test. Update expectations so the result includes:
+
+```ts
+expect(result).toContain("MCP Connect page is open:")
+expect(result).toContain("Grab config from Supabase Studio:")
+expect(result).toContain("In Connect -> MCP -> OpenCode, choose permissions.")
+expect(result).toContain("Copy the generated config under Configure MCP.")
+expect(result).toContain("Paste the Studio prompt or config snippet back here.")
+expect(result).toContain("Skip any install Supabase Agent Skills step; this plugin already bundles them.")
+expect(result).toContain("After adding config, restart OpenCode, then run:")
+expect(result).toContain("opencode mcp auth supabase")
+expect(result).toContain("Complete OAuth in the browser.")
+expect(result).not.toContain("if OAuth")
+expect(result).not.toContain("prompted automatically")
+```
+
+Preserve existing URL assertions for:
+
+```text
+https://supabase.com/dashboard/project/<project-ref>?showConnect=true&connectTab=mcp&mcpClient=opencode
+```
+
+- [ ] **Step 2: Run focused test to verify failures**
+
+Run:
+
+```bash
+bun run test test/server-tools.test.ts
+```
+
+Expected: FAIL because source output still says `On the Connect page:` and conditional OAuth wording.
+
+- [ ] **Step 3: Update `formatMcpSetupResult()` output**
+
+In `src/server/tools.ts`, replace the returned text from `formatMcpSetupResult(projectRef: string)` with:
+
+```ts
+return [
+  "MCP Connect page is open:",
+  url,
+  "",
+  "Grab config from Supabase Studio:",
+  "1. In Connect -> MCP -> OpenCode, choose permissions.",
+  "2. Copy the generated config under Configure MCP.",
+  "3. Paste the Studio prompt or config snippet back here.",
+  "",
+  "Skip any install Supabase Agent Skills step; this plugin already bundles them.",
+  "",
+  "After adding config, restart OpenCode, then run:",
+  "opencode mcp auth supabase",
+  "",
+  "Complete OAuth in the browser.",
+].join("\n")
+```
+
+Keep `createMcpSetupUrl(projectRef: string)` unchanged.
+
+- [ ] **Step 4: Update `supabase_open_mcp_setup` description**
+
+In `src/server/tools.ts`, update the tool description to stop telling agents to ask `Open Supabase MCP Connect page for <project name> (<project-ref>)?`. Use this description:
+
+```ts
+description:
+  "Open Supabase Studio MCP Connect page for a project after the user confirms the project. Use when the user asks to set up, connect, configure, or use Supabase MCP in OpenCode. Before calling, briefly explain that MCP adds project-scoped database, docs, advisor, and management tools. Ask a Question tool confirmation with an Open browser recommended option and a Skip setup option.",
+```
+
+- [ ] **Step 5: Run focused test to verify pass**
+
+Run:
+
+```bash
+bun run test test/server-tools.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit Task 2**
+
+Run:
+
+```bash
+git add src/server/tools.ts test/server-tools.test.ts
+git commit -m "fix(tools): clarify MCP setup instructions"
+```
+
+Expected: commit succeeds.
+
+### Task 3: Rewrite Guide Flow and Question Examples
+
+**Files:**
+- Modify: `skills/opencode-supabase-guide/SKILL.md`
+- Modify: `test/server-skills.test.ts` only if adding assertions for guide text
+
+- [ ] **Step 1: Add guide assertions only if existing tests already inspect skill content**
+
+Open `test/server-skills.test.ts`. If it only checks registration/enabling, do not add broad text assertions. If it already reads `SKILL.md` content, add these targeted assertions:
+
+```ts
+expect(skillContent).toContain("List projects first")
+expect(skillContent).toContain("Open browser (Recommended)")
+expect(skillContent).toContain("Do not add Other, Something else, or Type your own answer")
+expect(skillContent).toContain("OpenCode does not automatically start OAuth")
+expect(skillContent).toContain("opencode mcp auth supabase")
+```
+
+- [ ] **Step 2: Run guide-related test to verify current state**
+
+If `test/server-skills.test.ts` was changed, run:
+
+```bash
+bun run test test/server-skills.test.ts
+```
+
+Expected: FAIL until guide text is updated.
+
+If `test/server-skills.test.ts` was not changed, skip this step and rely on review plus full test suite.
+
+- [ ] **Step 3: Update setup ordering in guide**
+
+In `skills/opencode-supabase-guide/SKILL.md`, update the MCP flow section so it says:
+
+```markdown
+## MCP Setup Flow
+
+List projects first. Do not lead with MCP setup immediately after `/supabase` auth.
+
+1. If user has not chosen a project, call `supabase_list_projects`.
+2. If multiple projects exist, use the Question tool to choose one.
+3. After a project is selected, offer to connect that project to Supabase MCP.
+4. If user confirms, call `supabase_open_mcp_setup`.
+5. Tell user to paste the Studio prompt or OpenCode config snippet back here.
+6. After config is added, tell user to restart OpenCode, then run `opencode mcp auth supabase` and complete OAuth in the browser.
+```
+
+- [ ] **Step 4: Add exact Question tool confirmation example**
+
+In `skills/opencode-supabase-guide/SKILL.md`, add this example under the MCP setup flow:
+
+````markdown
+Use this Question tool shape before opening Studio:
+
+```json
+{
+  "questions": [
+    {
+      "header": "Connect Supabase",
+      "question": "Connect opencode-tester to Supabase MCP?",
+      "multiple": false,
+      "options": [
+        {
+          "label": "Open browser (Recommended)",
+          "description": "Open Supabase Studio to choose permissions and copy config"
+        },
+        {
+          "label": "Skip setup",
+          "description": "Do not connect Supabase MCP now"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Replace `opencode-tester` with the selected project name.
+````
+
+- [ ] **Step 5: Add Question tool anti-patterns**
+
+In `skills/opencode-supabase-guide/SKILL.md`, add:
+
+```markdown
+Question tool rules:
+
+- Do not add `Other`, `Something else`, `Type your own answer`, or catch-all options.
+- OpenCode adds `Type your own answer` automatically.
+- Put the recommended option first and include `(Recommended)` in the label.
+- Keep labels short and put explanatory text in `description`.
+```
+
+- [ ] **Step 6: Add explicit auth wording**
+
+In `skills/opencode-supabase-guide/SKILL.md`, replace conditional OAuth language with:
+
+````markdown
+OpenCode does not automatically start OAuth after config is added. After adding MCP config, tell the user:
+
+```text
+Restart OpenCode, then run:
+opencode mcp auth supabase
+
+Complete OAuth in the browser.
+```
+````
+
+Remove all guide wording equivalent to:
+
+```text
+if OAuth is not prompted automatically
+```
+
+- [ ] **Step 7: Add clearer existing-config wording**
+
+In `skills/opencode-supabase-guide/SKILL.md`, add this few-shot for already-wired config:
+
+````markdown
+If the Studio config is already present in `.opencode/opencode.json` or `.opencode/opencode.jsonc`, say:
+
+```text
+Supabase MCP config already exists for this workspace. No file changes needed.
+
+Restart OpenCode, then run:
+opencode mcp auth supabase
+
+Complete OAuth in the browser.
+```
+
+Do not say `already wired` without explaining the restart and auth steps.
+````
+
+- [ ] **Step 8: Run guide-related test**
+
+If `test/server-skills.test.ts` was changed, run:
+
+```bash
+bun run test test/server-skills.test.ts
+```
+
+Expected: PASS.
+
+If `test/server-skills.test.ts` was not changed, skip this step.
+
+- [ ] **Step 9: Commit Task 3**
+
+Run:
+
+```bash
+git add skills/opencode-supabase-guide/SKILL.md test/server-skills.test.ts
+git commit -m "fix(skill): clarify Supabase MCP setup flow"
+```
+
+Expected: commit succeeds. If `test/server-skills.test.ts` did not change, omit it from `git add`.
+
+### Task 4: Update README Docs
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README copy**
+
+In `README.md`, find the MCP onboarding section around the current prompt `Set up Supabase MCP for my project`. Replace that flow with:
+
+````markdown
+After connecting Supabase, start by asking OpenCode to list projects:
+
+```text
+List my Supabase projects
+```
+
+Pick the project you want to work with, then ask OpenCode to connect Supabase MCP for that project. OpenCode opens Supabase Studio so you can choose MCP permissions and copy the generated OpenCode config.
+
+After OpenCode adds the config, restart OpenCode and authenticate the MCP server:
+
+```bash
+opencode mcp auth supabase
+```
+
+Complete OAuth in the browser. Skip any `install Supabase Agent Skills` step in Studio; this plugin already bundles the Supabase skills.
+````
+
+- [ ] **Step 2: Check README for removed conditional auth wording**
+
+Search `README.md` for:
+
+```text
+if OAuth
+prompted automatically
+Set up Supabase MCP for my project
+```
+
+Expected: no remaining matches unless the old MCP prompt appears in a historical changelog section that should remain unchanged.
+
+- [ ] **Step 3: Commit Task 4**
+
+Run:
+
+```bash
+git add README.md
+git commit -m "docs: update Supabase MCP onboarding flow"
+```
+
+Expected: commit succeeds.
+
+### Task 5: Full Verification
+
+**Files:**
+- Verify all changed files
+
+- [ ] **Step 1: Run focused test suite**
+
+Run:
+
+```bash
+bun run test test/plugin-exports.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run server tool tests**
+
+Run:
+
+```bash
+bun run test test/server-tools.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run skill tests if changed**
+
+If `test/server-skills.test.ts` changed, run:
+
+```bash
+bun run test test/server-skills.test.ts
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint**
+
+Run:
+
+```bash
+bun run lint
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run typecheck**
+
+Run:
+
+```bash
+bun run typecheck
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Run full tests**
+
+Run:
+
+```bash
+bun run test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Run package verification**
+
+Run:
+
+```bash
+bun run verify:pack
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat
+git diff
+```
+
+Expected: diff only touches planned files and contains no `if OAuth isn't prompted automatically` wording.
+
+- [ ] **Step 9: Final commit if verification changed files**
+
+If verification changed generated files, commit them with:
+
+```bash
+git add <changed-generated-files>
+git commit -m "chore: update generated artifacts"
+```
+
+Expected: no commit needed unless a verification command intentionally updated generated output.
+
+## Self-Review Notes
+
+- Spec coverage: onboarding copy, setup tool output, guide flow, Question tool examples, README docs, and tests are covered.
+- Scope check: no MCP status tool, no no-restart flow, and no journal update are included.
+- Placeholder scan: plan contains no placeholder markers.
+- Type consistency: no new TypeScript APIs are introduced; existing string-returning plugin tool behavior is preserved.

--- a/skills/opencode-supabase-guide/SKILL.md
+++ b/skills/opencode-supabase-guide/SKILL.md
@@ -64,6 +64,79 @@ Use this Question tool shape before opening Studio:
 
 Replace `opencode-tester` with the selected project name.
 
+## Required Phrases
+
+Use explicit wording. Do not improvise around auth/setup state.
+
+After `/supabase` auth succeeds:
+
+Say this:
+
+```text
+Ask me to list your Supabase projects first.
+Then pick a project and ask me to connect it to MCP.
+```
+
+Do not say:
+
+```text
+Set up Supabase MCP for my project.
+```
+
+After project selection:
+
+Say this:
+
+```text
+Connect this project to Supabase MCP?
+```
+
+Do not say:
+
+```text
+I will set up MCP now.
+```
+
+After Studio config is pasted or applied:
+
+Say this:
+
+```text
+Restart OpenCode, then run `opencode mcp auth supabase`.
+Complete OAuth in the browser.
+```
+
+Do not say:
+
+```text
+OAuth will prompt automatically.
+Run auth if it does not work.
+```
+
+If config already exists:
+
+Say this:
+
+```text
+Supabase MCP config already exists for this workspace. No file changes needed.
+Restart OpenCode, then run `opencode mcp auth supabase`.
+```
+
+Do not say:
+
+```text
+Already wired.
+```
+
+If user says MCP works after only restarting:
+
+Say this:
+
+```text
+MCP auth may already be cached from an earlier setup.
+Restarting loaded the config; cached auth let the MCP server work without a new browser auth step.
+```
+
 ## OpenCode Auth
 
 OpenCode does not automatically start OAuth after config is added. After adding MCP config, tell the user:
@@ -111,4 +184,4 @@ Do not say `already wired` without explaining the restart and auth steps.
 
 ## Troubleshooting
 
-MCP tools missing after config? Restart OpenCode, run `opencode mcp auth supabase`.
+MCP tools missing after config? Say: `Restart OpenCode, then run opencode mcp auth supabase.`

--- a/skills/opencode-supabase-guide/SKILL.md
+++ b/skills/opencode-supabase-guide/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: opencode-supabase-guide
-description: Use when users ask to set up Supabase MCP in OpenCode, paste Supabase Studio MCP config, or need MCP tools connected.
+description: Use when users ask to set up Supabase MCP in OpenCode, connect project to MCP, connect a project to MCP, connect MCP, conenct MCP, connect MCP server, connect Supabase MCP, paste Supabase Studio MCP config, or need MCP tools connected.
 ---
 
 # OpenCode Supabase Guide
@@ -36,7 +36,33 @@ Supabase MCP adds project-scoped Supabase tools to OpenCode. Before MCP setup, t
 3. After a project is selected, offer to connect that project to Supabase MCP.
 4. If user confirms, call `supabase_open_mcp_setup`.
 5. Tell user to paste the Studio prompt or OpenCode config snippet back here.
-6. After config is added, tell user to restart OpenCode, then run `opencode mcp auth supabase` and complete OAuth in the browser.
+6. After config is added, tell user to close OpenCode or exit the current session, run `opencode mcp auth supabase`, complete OAuth in the browser, then start OpenCode again.
+
+User phrases that MUST trigger this flow include: `connect project to MCP`, `connect a project to MCP`, `connect MCP`, `conenct MCP`, `connect MCP server`, `connect Supabase MCP`, and `connect to Supabase MCP`.
+
+Never list projects as bullets and ask the user to reply in prose. Use this Question tool shape for project selection:
+
+```json
+{
+  "questions": [
+    {
+      "header": "Choose Project",
+      "question": "Which project do you want to connect to Supabase MCP?",
+      "multiple": false,
+      "options": [
+        {
+          "label": "opencode-tester",
+          "description": "Project ref: abcdefghijklmnopqrst"
+        },
+        {
+          "label": "analytics-prod",
+          "description": "Project ref: zyxwvutsrqponmlkjihg"
+        }
+      ]
+    }
+  ]
+}
+```
 
 Use this Question tool shape before opening Studio:
 
@@ -99,13 +125,14 @@ I will set up MCP now.
 
 After Studio config is pasted or applied:
 
-OAuth is a required separate step. OpenCode loads the MCP config only after restart, then `opencode mcp auth supabase` starts browser OAuth for that MCP server.
+OAuth is a required separate step. The current OpenCode TUI session cannot reload the MCP config. Close OpenCode or exit the current session, then `opencode mcp auth supabase` starts browser OAuth for that MCP server. Start OpenCode again after OAuth completes.
 
 Say this:
 
 ```text
-Restart OpenCode, then run `opencode mcp auth supabase`.
+Close OpenCode or exit the current session, then run `opencode mcp auth supabase`.
 Complete OAuth in the browser.
+Start OpenCode again after OAuth completes.
 ```
 
 Do not say:
@@ -115,7 +142,7 @@ OAuth starts by itself after restart.
 Run auth only if MCP fails.
 ```
 
-Never tell the user to wait for automatic OAuth. Always tell them to restart OpenCode, run `opencode mcp auth supabase`, and complete OAuth in the browser.
+Never tell the user to wait for automatic OAuth. Always tell them to close OpenCode or exit the current session, run `opencode mcp auth supabase`, complete OAuth in the browser, and start OpenCode again after OAuth completes.
 
 If config already exists:
 
@@ -123,7 +150,9 @@ Say this:
 
 ```text
 Supabase MCP config already exists for this workspace. No file changes needed.
-Restart OpenCode, then run `opencode mcp auth supabase`.
+Close OpenCode or exit the current session, then run `opencode mcp auth supabase`.
+Complete OAuth in the browser.
+Start OpenCode again after OAuth completes.
 ```
 
 Do not say:
@@ -146,10 +175,11 @@ Restarting loaded the config; cached auth let the MCP server work without a new 
 OpenCode does not automatically start OAuth after config is added. OAuth is a required separate step. After adding MCP config, tell the user:
 
 ```text
-Restart OpenCode, then run:
+Close OpenCode or exit the current session, then run:
 opencode mcp auth supabase
 
 Complete OAuth in the browser.
+Start OpenCode again after OAuth completes.
 ```
 
 ## Studio Prompt Handling
@@ -158,17 +188,18 @@ Extract MCP JSON from Studio prompt. Strip line numbers (`1{`). Preserve URLs ex
 
 ## Config Rules
 
-Prefer `.opencode/opencode.json` (or `.opencode/opencode.jsonc`). Global (`~/.config/opencode/opencode.json`) only on explicit request. Use `question` tool before editing. Remind to restart OpenCode.
+Prefer `.opencode/opencode.json` (or `.opencode/opencode.jsonc`). Global (`~/.config/opencode/opencode.json`) only on explicit request. Use `question` tool before editing. Remind to close OpenCode or exit the current session before auth, then start OpenCode again after OAuth completes.
 
 If the Studio config is already present in `.opencode/opencode.json` or `.opencode/opencode.jsonc`, say:
 
 ```text
 Supabase MCP config already exists for this workspace. No file changes needed.
 
-Restart OpenCode, then run:
+Close OpenCode or exit the current session, then run:
 opencode mcp auth supabase
 
 Complete OAuth in the browser.
+Start OpenCode again after OAuth completes.
 ```
 
 Do not say `already wired` without explaining the restart and auth steps.
@@ -184,8 +215,8 @@ Do not say `already wired` without explaining the restart and auth steps.
 | Choosing MCP features for user          | Studio decides read-only, feature groups |
 | Calling MCP setup while unauthenticated | Tell user to run `/supabase` first         |
 | Asking user without `question` tool     | Always use `question` tool for confirmations, project selection, any interactive choice |
-| Saying OAuth happens automatically      | OAuth is a required separate step: restart OpenCode, run `opencode mcp auth supabase`, complete browser OAuth |
+| Saying OAuth happens automatically      | OAuth is a required separate step: close OpenCode or exit the current session, run `opencode mcp auth supabase`, complete browser OAuth, start OpenCode again |
 
 ## Troubleshooting
 
-MCP tools missing after config? Say: `Restart OpenCode, then run opencode mcp auth supabase.`
+MCP tools missing after config? Say: `Close OpenCode or exit the current session, run opencode mcp auth supabase, complete OAuth, then start OpenCode again.`

--- a/skills/opencode-supabase-guide/SKILL.md
+++ b/skills/opencode-supabase-guide/SKILL.md
@@ -99,6 +99,8 @@ I will set up MCP now.
 
 After Studio config is pasted or applied:
 
+OAuth is a required separate step. OpenCode loads the MCP config only after restart, then `opencode mcp auth supabase` starts browser OAuth for that MCP server.
+
 Say this:
 
 ```text
@@ -109,9 +111,11 @@ Complete OAuth in the browser.
 Do not say:
 
 ```text
-OAuth will prompt automatically.
-Run auth if it does not work.
+OAuth starts by itself after restart.
+Run auth only if MCP fails.
 ```
+
+Never tell the user to wait for automatic OAuth. Always tell them to restart OpenCode, run `opencode mcp auth supabase`, and complete OAuth in the browser.
 
 If config already exists:
 
@@ -125,7 +129,7 @@ Restart OpenCode, then run `opencode mcp auth supabase`.
 Do not say:
 
 ```text
-Already wired.
+Config already wired.
 ```
 
 If user says MCP works after only restarting:
@@ -139,7 +143,7 @@ Restarting loaded the config; cached auth let the MCP server work without a new 
 
 ## OpenCode Auth
 
-OpenCode does not automatically start OAuth after config is added. After adding MCP config, tell the user:
+OpenCode does not automatically start OAuth after config is added. OAuth is a required separate step. After adding MCP config, tell the user:
 
 ```text
 Restart OpenCode, then run:
@@ -180,7 +184,7 @@ Do not say `already wired` without explaining the restart and auth steps.
 | Choosing MCP features for user          | Studio decides read-only, feature groups |
 | Calling MCP setup while unauthenticated | Tell user to run `/supabase` first         |
 | Asking user without `question` tool     | Always use `question` tool for confirmations, project selection, any interactive choice |
-| Saying OAuth happens automatically      | OpenCode detects `needs_auth` but does not auto-start browser OAuth; user must run `opencode mcp auth supabase` |
+| Saying OAuth happens automatically      | OAuth is a required separate step: restart OpenCode, run `opencode mcp auth supabase`, complete browser OAuth |
 
 ## Troubleshooting
 

--- a/skills/opencode-supabase-guide/SKILL.md
+++ b/skills/opencode-supabase-guide/SKILL.md
@@ -9,31 +9,92 @@ description: Use when users ask to set up Supabase MCP in OpenCode, paste Supaba
 
 Every interactive choice MUST use `question` tool. Never assume, never auto-pick. This includes:
 
-- Selecting a project when multiple exist — list options with name + ref in the question.
-- Confirming before opening browser — include project name + ref in the question.
+- Selecting a project when multiple exist -- list options with name + ref in the question.
+- Confirming before opening browser -- include project name + ref in the question.
 - Choosing whether to apply Studio config to the repo.
 - Any yes/no or selection prompt.
 
-No prose "ask" — always `question` tool invocation.
+No prose "ask" -- always `question` tool invocation.
+
+Question tool rules:
+
+- Do not add `Other`, `Something else`, `Type your own answer`, or catch-all options.
+- OpenCode adds `Type your own answer` automatically.
+- Put the recommended option first and include `(Recommended)` in the label.
+- Keep labels short and put explanatory text in `description`.
 
 ## Overview
 
-Supabase MCP adds project-scoped Supabase tools to OpenCode. Before MCP setup, tell user to run `/supabase` to connect their account — plugin tools (list projects, create project) need OAuth. MCP config comes from Studio prompt, not rebuilt from code.
+List projects first. Do not lead with MCP setup immediately after `/supabase` auth.
+
+Supabase MCP adds project-scoped Supabase tools to OpenCode. Before MCP setup, tell user to run `/supabase` to connect their account -- plugin tools (list projects, create project) need OAuth. MCP config comes from Studio prompt, not rebuilt from code.
 
 ## MCP Setup Flow
 
-1. Resolve project with `supabase_list_projects`. If auth fails, tell user: "Run `/supabase` to connect your Supabase account." If multiple projects, use `question` tool listing name + ref for each.
-2. Use `question` tool to confirm: "Open Supabase MCP Connect for `<name>` (`<ref>`)?"
-3. Call `supabase_open_mcp_setup`. Always print returned URL in output.
-4. Tell user to paste Studio prompt/config back for wiring into `.opencode/opencode.json`.
+1. If user has not chosen a project, call `supabase_list_projects`.
+2. If multiple projects exist, use the Question tool to choose one.
+3. After a project is selected, offer to connect that project to Supabase MCP.
+4. If user confirms, call `supabase_open_mcp_setup`.
+5. Tell user to paste the Studio prompt or OpenCode config snippet back here.
+6. After config is added, tell user to restart OpenCode, then run `opencode mcp auth supabase` and complete OAuth in the browser.
+
+Use this Question tool shape before opening Studio:
+
+```json
+{
+  "questions": [
+    {
+      "header": "Connect Supabase",
+      "question": "Connect opencode-tester to Supabase MCP?",
+      "multiple": false,
+      "options": [
+        {
+          "label": "Open browser (Recommended)",
+          "description": "Open Supabase Studio to choose permissions and copy config"
+        },
+        {
+          "label": "Skip setup",
+          "description": "Do not connect Supabase MCP now"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Replace `opencode-tester` with the selected project name.
+
+## OpenCode Auth
+
+OpenCode does not automatically start OAuth after config is added. After adding MCP config, tell the user:
+
+```text
+Restart OpenCode, then run:
+opencode mcp auth supabase
+
+Complete OAuth in the browser.
+```
 
 ## Studio Prompt Handling
 
-Extract MCP JSON from Studio prompt. Strip line numbers (`1{`). Preserve URLs exactly — never rebuild from `project_ref`. MCP server key usually `supabase`; auth: `opencode mcp auth supabase`. Skip `npx skills add supabase/agent-skills` — already bundled.
+Extract MCP JSON from Studio prompt. Strip line numbers (`1{`). Preserve URLs exactly -- never rebuild from `project_ref`. MCP server key usually `supabase`; auth: `opencode mcp auth supabase`. Skip `npx skills add supabase/agent-skills` -- already bundled.
 
 ## Config Rules
 
 Prefer `.opencode/opencode.json` (or `.opencode/opencode.jsonc`). Global (`~/.config/opencode/opencode.json`) only on explicit request. Use `question` tool before editing. Remind to restart OpenCode.
+
+If the Studio config is already present in `.opencode/opencode.json` or `.opencode/opencode.jsonc`, say:
+
+```text
+Supabase MCP config already exists for this workspace. No file changes needed.
+
+Restart OpenCode, then run:
+opencode mcp auth supabase
+
+Complete OAuth in the browser.
+```
+
+Do not say `already wired` without explaining the restart and auth steps.
 
 ## Common Mistakes
 
@@ -46,6 +107,7 @@ Prefer `.opencode/opencode.json` (or `.opencode/opencode.jsonc`). Global (`~/.co
 | Choosing MCP features for user          | Studio decides read-only, feature groups |
 | Calling MCP setup while unauthenticated | Tell user to run `/supabase` first         |
 | Asking user without `question` tool     | Always use `question` tool for confirmations, project selection, any interactive choice |
+| Saying OAuth happens automatically      | OpenCode detects `needs_auth` but does not auto-start browser OAuth; user must run `opencode mcp auth supabase` |
 
 ## Troubleshooting
 

--- a/src/server/auth-html.ts
+++ b/src/server/auth-html.ts
@@ -103,6 +103,8 @@ export const HTML_SUCCESS = `<!doctype html>
       <p>You can <strong>close this window</strong> and return to OpenCode.</p>
       <div class="prompt-label">Try this next:</div>
       <div class="prompt-box">list my Supabase projects</div>
+      <div class="prompt-label">Then try:</div>
+      <div class="prompt-box">connect a project to MCP</div>
       <div class="footer">Having troubles or found a bug?<br><a href="${REPO_URL}" target="_blank" rel="noopener">Report it on GitHub</a></div>
     </div>
     <script>setTimeout(function(){window.close()},2000)</script>

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -431,7 +431,7 @@ function createMcpSetupUrl(projectRef: string) {
   return url.toString();
 }
 
-function formatMcpSetupResult(projectRef: string, url: string) {
+function formatMcpSetupResult(url: string) {
   return [
     "MCP Connect page is open:",
     url,
@@ -571,7 +571,7 @@ export function createSupabaseTools(
           messageID: _context.messageID,
           agent: _context.agent,
         });
-        return formatMcpSetupResult(args.project_ref, url);
+        return formatMcpSetupResult(url);
       },
     }),
     supabase_login: tool({

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -432,17 +432,22 @@ function createMcpSetupUrl(projectRef: string) {
 }
 
 function formatMcpSetupResult(projectRef: string, url: string) {
-  return `Opened Supabase MCP setup for project ${projectRef} in Studio.
-
-URL: ${url}
-
-On the Connect page:
-1. Confirm MCP tab and OpenCode client are selected.
-2. Choose the feature groups and permissions you want in Studio.
-3. Follow the OpenCode config and auth steps shown by Studio.
-4. If you want me to wire this into the current repo, paste the Studio prompt or OpenCode config snippet back here.
-5. You can skip any "install Supabase Agent Skills" step because this plugin already bundles them.
-6. Restart OpenCode after changing config; run \`opencode mcp auth supabase\` if OAuth is not prompted automatically.`;
+  return [
+    "MCP Connect page is open:",
+    url,
+    "",
+    "Grab config from Supabase Studio:",
+    "1. In Connect -> MCP -> OpenCode, choose permissions.",
+    "2. Copy the generated config under Configure MCP.",
+    "3. Paste the Studio prompt or config snippet back here.",
+    "",
+    "Skip any install Supabase Agent Skills step; this plugin already bundles them.",
+    "",
+    "After adding config, restart OpenCode, then run:",
+    "opencode mcp auth supabase",
+    "",
+    "Complete OAuth in the browser.",
+  ].join("\n")
 }
 
 export function createSupabaseTools(
@@ -551,7 +556,7 @@ export function createSupabaseTools(
     }),
     supabase_open_mcp_setup: tool({
       description:
-        "Open Supabase Studio MCP Connect page for a project after the user confirms the project. Use when the user asks to set up, connect, configure, or use Supabase MCP in OpenCode. Before calling, explain MCP briefly and ask: Open Supabase MCP Connect page for <project name> (<project-ref>)?",
+        "Open Supabase Studio MCP Connect page for a project after the user confirms the project. Use when the user asks to set up, connect, configure, or use Supabase MCP in OpenCode. Before calling, briefly explain that MCP adds project-scoped database, docs, advisor, and management tools. Ask a Question tool confirmation with an Open browser recommended option and a Skip setup option.",
       args: {
         project_ref: tool.schema.string().describe("Supabase project reference ID"),
       },

--- a/src/server/tools.ts
+++ b/src/server/tools.ts
@@ -443,10 +443,12 @@ function formatMcpSetupResult(url: string) {
     "",
     "Skip any install Supabase Agent Skills step; this plugin already bundles them.",
     "",
-    "After adding config, restart OpenCode, then run:",
+    "After adding config:",
+    "1. Close OpenCode or exit the current session.",
+    "2. Run:",
     "opencode mcp auth supabase",
-    "",
-    "Complete OAuth in the browser.",
+    "3. Complete OAuth in the browser.",
+    "4. Start OpenCode again.",
   ].join("\n")
 }
 

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -22,16 +22,16 @@ type SupabaseDialogProps = {
 
 const ONBOARDING_MESSAGE = `Supabase is connected.
 
-Now unlock project-scoped tools with Supabase MCP — ask me to set it up to get database inspection, docs, advisors, and more for your project in OpenCode.
+Start by listing your Supabase projects, then connect project-scoped MCP tools for database inspection, docs, advisors, and more in OpenCode.
 
 You can also ask about:
-- your organizations and projects
-- API keys for a project
-- available database regions
+- organizations and projects
+- API keys
+- regions
 - creating a new project
 
 Try this:
-Set up Supabase MCP for my project`;
+List my Supabase projects`;
 
 const onboardedSessionIDsByApi = new WeakMap<TuiPluginApi, Set<string>>();
 

--- a/src/tui/dialog.tsx
+++ b/src/tui/dialog.tsx
@@ -679,7 +679,8 @@ export function SupabaseDialog(props: SupabaseDialogProps) {
 
   return props.api.ui.DialogAlert({
     title: "Connected to Supabase",
-    message: "Your account is ready. Close this dialog and ask me to list your Supabase projects.",
+    message:
+      "Your account is ready. Close this dialog, ask me to list your Supabase projects, then ask me to connect one to MCP.",
     onConfirm: closeDialog,
   });
 }

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -1544,6 +1544,8 @@ test("auth success html includes a small prompt snippet", () => {
   expect(HTML_SUCCESS).toContain("You can <strong>close this window</strong> and return to OpenCode.");
   expect(HTML_SUCCESS).toContain("Try this next:");
   expect(HTML_SUCCESS).toContain("list my Supabase projects");
+  expect(HTML_SUCCESS).toContain("Then try:");
+  expect(HTML_SUCCESS).toContain("connect a project to MCP");
 });
 
 test("supabase dialog logs auth milestones without leaking oauth query values", async () => {

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -438,7 +438,7 @@ test("supabase auth success injects ignored onboarding into current session", as
         expect.objectContaining({
           type: "text",
           ignored: true,
-          text: expect.stringContaining("your organizations and projects"),
+          text: expect.stringContaining("organizations and projects"),
         }),
       ],
     }),
@@ -665,7 +665,7 @@ test("supabase already-connected confirm saves onboarding before navigating from
           {
             type: "text",
             ignored: true,
-            text: "Supabase is connected.\n\nNow unlock project-scoped tools with Supabase MCP — ask me to set it up to get database inspection, docs, advisors, and more for your project in OpenCode.\n\nYou can also ask about:\n- your organizations and projects\n- API keys for a project\n- available database regions\n- creating a new project\n\nTry this:\nSet up Supabase MCP for my project",
+            text: "Supabase is connected.\n\nStart by listing your Supabase projects, then connect project-scoped MCP tools for database inspection, docs, advisors, and more in OpenCode.\n\nYou can also ask about:\n- organizations and projects\n- API keys\n- regions\n- creating a new project\n\nTry this:\nList my Supabase projects",
           },
         ],
       },

--- a/test/plugin-exports.test.ts
+++ b/test/plugin-exports.test.ts
@@ -391,7 +391,7 @@ test("supabase dialog success closes without inserting an example prompt", async
 
   expect(successDialog.title).toBe("Connected to Supabase");
   expect(successDialog.message).toBe(
-    "Your account is ready. Close this dialog and ask me to list your Supabase projects.",
+    "Your account is ready. Close this dialog, ask me to list your Supabase projects, then ask me to connect one to MCP.",
   );
   expect((successDialog as Record<string, unknown>).onCancel).toBeUndefined();
   expect(api.__test.dialogAlerts).toHaveLength(1);

--- a/test/server-skills.test.ts
+++ b/test/server-skills.test.ts
@@ -194,7 +194,10 @@ describe("opencode-supabase-guide skill", () => {
     expect(skillContent).toContain("Connect this project to Supabase MCP?");
     expect(skillContent).toContain("Restart OpenCode, then run `opencode mcp auth supabase`.");
     expect(skillContent).toContain("MCP auth may already be cached from an earlier setup.");
-    expect(skillContent).toContain("OAuth will prompt automatically");
-    expect(skillContent).toContain("Already wired");
+    expect(skillContent).toContain("OAuth is a required separate step.");
+    expect(skillContent).toContain("Never tell the user to wait for automatic OAuth.");
+    expect(skillContent).toContain("No file changes needed.");
+    expect(skillContent).not.toContain("OAuth will prompt automatically");
+    expect(skillContent).not.toContain("Already wired");
   });
 });

--- a/test/server-skills.test.ts
+++ b/test/server-skills.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
 import path from "node:path";
 import serverModule from "../src/server/index.ts";
 import {
@@ -180,5 +181,20 @@ describe("server config hook", () => {
       ],
       urls: ["https://example.com/.well-known/skills/"],
     });
+  });
+});
+
+describe("opencode-supabase-guide skill", () => {
+  test("documents strict MCP onboarding phrases", () => {
+    const skillContent = readFileSync(path.join(defaultSkillsRoot(), "opencode-supabase-guide", "SKILL.md"), "utf-8");
+
+    expect(skillContent).toContain("Say this:");
+    expect(skillContent).toContain("Do not say:");
+    expect(skillContent).toContain("Ask me to list your Supabase projects first.");
+    expect(skillContent).toContain("Connect this project to Supabase MCP?");
+    expect(skillContent).toContain("Restart OpenCode, then run `opencode mcp auth supabase`.");
+    expect(skillContent).toContain("MCP auth may already be cached from an earlier setup.");
+    expect(skillContent).toContain("OAuth will prompt automatically");
+    expect(skillContent).toContain("Already wired");
   });
 });

--- a/test/server-skills.test.ts
+++ b/test/server-skills.test.ts
@@ -190,13 +190,23 @@ describe("opencode-supabase-guide skill", () => {
 
     expect(skillContent).toContain("Say this:");
     expect(skillContent).toContain("Do not say:");
+    expect(skillContent).toContain("connect project to MCP");
+    expect(skillContent).toContain("connect a project to MCP");
+    expect(skillContent).toContain("connect MCP");
+    expect(skillContent).toContain("conenct MCP");
+    expect(skillContent).toContain("connect MCP server");
+    expect(skillContent).toContain("connect Supabase MCP");
+    expect(skillContent).toContain("Which project do you want to connect to Supabase MCP?");
+    expect(skillContent).toContain("Never list projects as bullets and ask the user to reply in prose.");
     expect(skillContent).toContain("Ask me to list your Supabase projects first.");
     expect(skillContent).toContain("Connect this project to Supabase MCP?");
-    expect(skillContent).toContain("Restart OpenCode, then run `opencode mcp auth supabase`.");
+    expect(skillContent).toContain("Close OpenCode or exit the current session, then run `opencode mcp auth supabase`.");
+    expect(skillContent).toContain("Start OpenCode again after OAuth completes.");
     expect(skillContent).toContain("MCP auth may already be cached from an earlier setup.");
     expect(skillContent).toContain("OAuth is a required separate step.");
     expect(skillContent).toContain("Never tell the user to wait for automatic OAuth.");
     expect(skillContent).toContain("No file changes needed.");
+    expect(skillContent).not.toContain("Restart OpenCode, then run `opencode mcp auth supabase`.");
     expect(skillContent).not.toContain("OAuth will prompt automatically");
     expect(skillContent).not.toContain("Already wired");
   });

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -1911,14 +1911,20 @@ describe("server tools auth helper", () => {
     expect(openMock).toHaveBeenCalledWith(
       "https://supabase.com/dashboard/project/yepepldpwepdbczomujk?showConnect=true&connectTab=mcp&mcpClient=opencode",
     );
-    expect(result).toContain("Opened Supabase MCP setup for project yepepldpwepdbczomujk in Studio.");
+    expect(result).toContain("MCP Connect page is open:");
     expect(result).toContain(
-      "URL: https://supabase.com/dashboard/project/yepepldpwepdbczomujk?showConnect=true&connectTab=mcp&mcpClient=opencode",
+      "https://supabase.com/dashboard/project/yepepldpwepdbczomujk?showConnect=true&connectTab=mcp&mcpClient=opencode",
     );
-    expect(result).toContain("paste the Studio prompt or OpenCode config snippet back here");
-    expect(result).toContain("skip any \"install Supabase Agent Skills\" step");
-    expect(result).toContain("Restart OpenCode after changing config");
+    expect(result).toContain("Grab config from Supabase Studio:");
+    expect(result).toContain("In Connect -> MCP -> OpenCode, choose permissions.");
+    expect(result).toContain("Copy the generated config under Configure MCP.");
+    expect(result).toContain("Paste the Studio prompt or config snippet back here.");
+    expect(result).toContain("Skip any install Supabase Agent Skills step; this plugin already bundles them.");
+    expect(result).toContain("After adding config, restart OpenCode, then run:");
     expect(result).toContain("opencode mcp auth supabase");
+    expect(result).toContain("Complete OAuth in the browser.");
+    expect(result).not.toContain("if OAuth");
+    expect(result).not.toContain("prompted automatically");
   });
 
   test("requires Supabase auth before opening MCP setup page", async () => {

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -1925,6 +1925,7 @@ describe("server tools auth helper", () => {
     expect(result).toContain("Complete OAuth in the browser.");
     expect(result).not.toContain("if OAuth");
     expect(result).not.toContain("prompted automatically");
+    expect(result).not.toContain("if it does not work");
   });
 
   test("requires Supabase auth before opening MCP setup page", async () => {

--- a/test/server-tools.test.ts
+++ b/test/server-tools.test.ts
@@ -1920,9 +1920,13 @@ describe("server tools auth helper", () => {
     expect(result).toContain("Copy the generated config under Configure MCP.");
     expect(result).toContain("Paste the Studio prompt or config snippet back here.");
     expect(result).toContain("Skip any install Supabase Agent Skills step; this plugin already bundles them.");
-    expect(result).toContain("After adding config, restart OpenCode, then run:");
+    expect(result).toContain("After adding config:");
+    expect(result).toContain("1. Close OpenCode or exit the current session.");
+    expect(result).toContain("2. Run:");
     expect(result).toContain("opencode mcp auth supabase");
-    expect(result).toContain("Complete OAuth in the browser.");
+    expect(result).toContain("3. Complete OAuth in the browser.");
+    expect(result).toContain("4. Start OpenCode again.");
+    expect(result).not.toContain("After adding config, restart OpenCode, then run:");
     expect(result).not.toContain("if OAuth");
     expect(result).not.toContain("prompted automatically");
     expect(result).not.toContain("if it does not work");


### PR DESCRIPTION
## Summary
- Lead onboarding with project listing, not MCP setup
- Clarify MCP setup tool output with numbered steps and explicit auth instructions
- Rewrite guide SKILL.md with Question tool examples, conditional-removal of OAuth auto-prompt language
- Update README MCP flow to match new onboarding sequence
- All tests pass (181/181), lint + typecheck clean

## Test Plan
- [ ] `bun run test` — 181 pass
- [ ] `bun run lint` — clean
- [ ] `bun run typecheck` — clean
- [ ] `bun run verify:pack` — clean