### PR TITLE
feat: update default OAuth broker URL and client ID for new Supabase project deployment

### DIFF
--- a/.changeset/update-oauth-broker-for-new-project.md
+++ b/.changeset/update-oauth-broker-for-new-project.md
@@ -1,0 +1,5 @@
+---
+"opencode-supabase": minor
+---
+
+Update default OAuth broker URL and client ID for new Supabase project deployment

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -1,7 +1,7 @@
 export const DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL = "https://api.supabase.com/v1/oauth/authorize";
 export const DEFAULT_SUPABASE_API_BASE_URL = "https://api.supabase.com/v1";
-export const DEFAULT_SUPABASE_BROKER_URL = "https://iaoxncwzemnfxcdwakzb.supabase.co/functions/v1/opencode-supabase-broker";
-export const DEFAULT_SUPABASE_OAUTH_CLIENT_ID = "80c76733-1b96-424b-976b-5c2977c72008";
+export const DEFAULT_SUPABASE_BROKER_URL = "https://mujltteqbakexagllqjg.supabase.co/functions/v1/opencode-supabase-broker";
+export const DEFAULT_SUPABASE_OAUTH_CLIENT_ID = "254ee667-f2c8-4c44-b7ad-e48232dcbd44";
 export const DEFAULT_SUPABASE_OAUTH_PORT = 14589;
 
 import type { FetchLike, SupabaseSharedConfig } from "./types.ts";

--- a/test/shared-modules.test.ts
+++ b/test/shared-modules.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, mock, test } from "bun:test";
 
 import {
   DEFAULT_SUPABASE_API_BASE_URL,
+  DEFAULT_SUPABASE_BROKER_URL,
   DEFAULT_SUPABASE_OAUTH_AUTHORIZE_URL,
   DEFAULT_SUPABASE_OAUTH_CLIENT_ID,
   DEFAULT_SUPABASE_OAUTH_PORT,
@@ -95,7 +96,7 @@ describe("shared config", () => {
       {},
     );
 
-    expect(config.brokerBaseUrl).toBe("https://iaoxncwzemnfxcdwakzb.supabase.co/functions/v1/opencode-supabase-broker");
+    expect(config.brokerBaseUrl).toBe(DEFAULT_SUPABASE_BROKER_URL);
   });
 
   test("uses the fixed default oauth port regardless of overrides", () => {


### PR DESCRIPTION
Update the default Supabase broker URL and OAuth client ID for the newly deployed project.

- Broker URL: `mujltteqbakexagllqjg.supabase.co`
- OAuth client ID: `254ee667-f2c8-4c44-b7ad-e48232dcbd44`